### PR TITLE
feat: add put to useUpdateTask hook

### DIFF
--- a/lib/hooks/useTasks.ts
+++ b/lib/hooks/useTasks.ts
@@ -1,6 +1,6 @@
 import useSWR, { useSWRConfig } from 'swr';
 import { Task } from '../types/apiTypes';
-import { get, post } from '../utils/fetch';
+import { get, post, put } from '../utils/fetch';
 import { swrToData, ApiResponseType } from '../types/swrUtil';
 
 const taskEndpointURL = `${process.env.NEXT_PUBLIC_API_URL}/task`;
@@ -11,6 +11,7 @@ type TaskList = {
 
 type UpdateTasks = {
     postTask: (task: Task) => void;
+    putTask: (task: Task) => void;
 };
 
 function useTasks(projectId: number): TaskList {
@@ -28,7 +29,13 @@ export const useUpdateTasks = (): UpdateTasks => {
         mutate(taskEndpointURL);
         return response;
     };
-    return { postTask };
+
+    const putTask = async (task: Task) => {
+        const response = await put(taskEndpointURL, task);
+        mutate(taskEndpointURL);
+        return response;
+    };
+    return { postTask, putTask };
 };
 
 export default useTasks;


### PR DESCRIPTION
This adds `put` to `useUpdateTasks` hook. This PR should make for a nice reference on how to add missing HTTP requests to these hooks I wrote.

Regarding the thing we tried earlier @oskarikerppo: The correct combination to achieve #74 is to merge this pull request, then just use
```
const { putTask } = useUpdateTasks()
```
in the TaskRow component the way we discussed before. You don't need the `projectId` in the PUT request in any way.

~~The tasks do update correctly: their status will be set to `ARCHIVED`. They don't disappear from the UI though, because they are not filtered correctly. I guess the `GET` method for tasks needs to be updated somehow in the backend.~~

For the tasks to disappear from the UI you will also need to [filter](https://github.com/three-consulting/epoc-frontend/blob/main/components/table/TimesheetTable.tsx#L29) them.