### PR TITLE
Refactor/idiomatic forms

### DIFF
--- a/components/form/CustomerForm.tsx
+++ b/components/form/CustomerForm.tsx
@@ -29,7 +29,7 @@ const validateCustomerFields = (fields: CustomerFields): Customer => {
     }
 };
 
-function CustomerForm(): JSX.Element {
+function CreateCustomerForm(): JSX.Element {
     const [customerFields, setCustomerFields] = useState<CustomerFields>({});
     const { isOpen, onOpen, onClose } = useDisclosure();
     const [errorMessage, setErrorMessage] = useState<string>('');
@@ -101,4 +101,4 @@ function CustomerForm(): JSX.Element {
     );
 }
 
-export default CustomerForm;
+export default CreateCustomerForm;

--- a/components/form/ProjectForm.tsx
+++ b/components/form/ProjectForm.tsx
@@ -4,7 +4,7 @@ import { Flex } from '@chakra-ui/layout';
 import { Button, FormControl, FormErrorMessage, FormLabel, Input, Select } from '@chakra-ui/react';
 import { useRouter } from 'next/router';
 import React, { useState } from 'react';
-import CustomerForm from './CustomerForm';
+import CreateCustomerForm from './CustomerForm';
 
 type ProjectFields = Partial<Project>;
 
@@ -117,7 +117,7 @@ function ProjectForm({ project: projectOrNull, customers, employees, onSubmit }:
                                     );
                                 })}
                             </Select>
-                            <CustomerForm />
+                            <CreateCustomerForm />
                         </Flex>
                     </FormControl>
                 </Flex>

--- a/components/form/ProjectForm.tsx
+++ b/components/form/ProjectForm.tsx
@@ -23,7 +23,9 @@ const validateProjectFields = (form: ProjectFields): Project => {
     }
 };
 
-function ProjectFormBody({ project: projectOrNull, customers, employees, onSubmit }: ProjectFormBodyProps) {
+type ProjectFormProps = EditProjectFormProps & { onSubmit: (project: Project) => void };
+
+function ProjectForm({ project: projectOrNull, customers, employees, onSubmit }: ProjectFormProps) {
     const router = useRouter();
     const [projectFields, setProjectFields] = useState<ProjectFields>(projectOrNull || {});
     const handleCustomerChange = (e: React.FormEvent<HTMLSelectElement>) => {
@@ -147,37 +149,32 @@ function ProjectFormBody({ project: projectOrNull, customers, employees, onSubmi
     );
 }
 
-type ProjectFormPropsBase = {
+type CreateProjectFormProps = {
     employees: Employee[];
     customers: Customer[];
 };
 
-type CreateProjectFormProps = ProjectFormPropsBase & { project: undefined; projectId: undefined };
-type EditProjectFormProps = ProjectFormPropsBase & { project: Project; projectId: number };
-type ProjectFormProps = CreateProjectFormProps | EditProjectFormProps;
-type ProjectFormBodyProps = ProjectFormProps & { onSubmit: (project: Project) => void };
-
-function CreateProjectForm(props: ProjectFormProps) {
+export const CreateProjectForm = (props: CreateProjectFormProps): JSX.Element => {
     const router = useRouter();
     const { postProject } = useUpdateProjects();
     const onSubmit = async (project: Project) => {
         await postProject(project);
         router.push('/projects');
     };
-    return <ProjectFormBody {...props} onSubmit={onSubmit} />;
-}
+    return <ProjectForm {...props} project={undefined} projectId={undefined} onSubmit={onSubmit} />;
+};
 
-function EditProjectForm(props: EditProjectFormProps) {
+type EditProjectFormProps = CreateProjectFormProps & {
+    project?: Project;
+    projectId?: number;
+};
+
+export const EditProjectForm = (props: EditProjectFormProps): JSX.Element => {
     const router = useRouter();
     const { putProject } = useUpdateProjects();
     const onSubmit = async (project: Project) => {
         await putProject(project);
         router.push(`/projects/${props.projectId}`);
     };
-    return <ProjectFormBody {...props} onSubmit={onSubmit} />;
-}
-
-const ProjectForm = (props: ProjectFormProps): JSX.Element =>
-    props.projectId ? <EditProjectForm {...props} /> : <CreateProjectForm {...props} />;
-
-export default ProjectForm;
+    return <ProjectForm {...props} onSubmit={onSubmit} />;
+};

--- a/components/form/TaskForm.tsx
+++ b/components/form/TaskForm.tsx
@@ -24,7 +24,7 @@ interface TaskFormProps {
     onClose: () => void;
 }
 
-export function TaskForm({ project, onClose }: TaskFormProps): JSX.Element {
+export function CreateTaskForm({ project, onClose }: TaskFormProps): JSX.Element {
     const [taskFields, setTaskFields] = useState<TaskFields>({
         project: project,
     });

--- a/components/form/TimesheetForm.tsx
+++ b/components/form/TimesheetForm.tsx
@@ -28,7 +28,7 @@ interface TimesheetFormProps {
     onClose: () => void;
 }
 
-export function TimesheetForm({ project, employees, onClose }: TimesheetFormProps): JSX.Element {
+export function CreateTimesheetForm({ project, employees, onClose }: TimesheetFormProps): JSX.Element {
     const [timesheetFields, setTimesheetFields] = useState<TimesheetFields>({ project });
     const [errorMessage, setErrorMessage] = useState<string>('');
     const { postTimesheet } = useUpdateTimesheets();

--- a/components/table/TaskTable.tsx
+++ b/components/table/TaskTable.tsx
@@ -4,7 +4,7 @@ import { Box, Flex, Heading } from '@chakra-ui/layout';
 import { Modal, ModalCloseButton, ModalContent, ModalHeader, ModalOverlay, Tbody } from '@chakra-ui/react';
 import { Table, Td, Th, Thead, Tr } from '@chakra-ui/table';
 import React, { useState } from 'react';
-import { TaskForm } from '../form/TaskForm';
+import { CreateTaskForm } from '../form/TaskForm';
 
 interface TaskRowProps {
     task: Task;
@@ -77,7 +77,7 @@ function TaskTable({ project, tasks }: TaskTableProps): JSX.Element {
                         <ModalContent px="0.5rem">
                             <ModalHeader>Add task to project</ModalHeader>
                             <ModalCloseButton />
-                            <TaskForm
+                            <CreateTaskForm
                                 project={project}
                                 projectId={project.id}
                                 onClose={() => setDisplayNewTaskForm(false)}

--- a/components/table/TimesheetTable.tsx
+++ b/components/table/TimesheetTable.tsx
@@ -5,7 +5,7 @@ import { Table, Tbody, Td, Th, Thead, Tr } from '@chakra-ui/table';
 import React, { useState } from 'react';
 import ErrorAlert from '../common/ErrorAlert';
 import { Employee, Project, Timesheet } from '@/lib/types/apiTypes';
-import { TimesheetForm } from '../form/TimesheetForm';
+import { CreateTimesheetForm } from '../form/TimesheetForm';
 import { useUpdateTimesheets } from '@/lib/hooks/useTimesheets';
 
 interface TimesheetRowProps {
@@ -103,7 +103,7 @@ function TimesheetTable({ project, timesheets, employees }: TimesheetTableProps)
                 <ModalOverlay />
                 <ModalContent px="0.5rem">
                     <ModalHeader>Add user to project</ModalHeader>
-                    <TimesheetForm
+                    <CreateTimesheetForm
                         project={project}
                         employees={employees}
                         onClose={() => setDisplayNewTimesheetForm(false)}

--- a/pages/projects/[id]/edit.tsx
+++ b/pages/projects/[id]/edit.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 import type { NextPage } from 'next';
 import { Heading } from '@chakra-ui/layout';
 import Layout from '@/components/common/Layout';
-import ProjectForm from '@/components/form/ProjectForm';
+import { EditProjectForm } from '@/components/form/ProjectForm';
 import ErrorAlert from '@/components/common/ErrorAlert';
 import Loading from '@/components/common/Loading';
 import { useRouter } from 'next/dist/client/router';
@@ -40,7 +40,7 @@ function EditProjectPage({ id }: Props): JSX.Element {
                 employeesResponse.isSuccess &&
                 projectDetailResponse.isSuccess &&
                 projectDetailResponse.data.id && (
-                    <ProjectForm
+                    <EditProjectForm
                         customers={customersResponse.data}
                         employees={employeesResponse.data}
                         project={projectDetailResponse.data}

--- a/pages/projects/new.tsx
+++ b/pages/projects/new.tsx
@@ -2,11 +2,11 @@ import React from 'react';
 import type { NextPage } from 'next';
 import { Heading } from '@chakra-ui/layout';
 import Layout from '@/components/common/Layout';
-import ProjectForm from '@/components/form/ProjectForm';
 import ErrorAlert from '@/components/common/ErrorAlert';
 import Loading from '@/components/common/Loading';
 import { useCustomers } from '@/lib/hooks/useCustomers';
 import { useEmployees } from '@/lib/hooks/useEmployees';
+import { CreateProjectForm } from '@/components/form/ProjectForm';
 
 const New: NextPage = () => {
     const { customersResponse } = useCustomers();
@@ -27,12 +27,7 @@ const New: NextPage = () => {
                 <ErrorAlert title={errorMessage} message={errorMessage} />
             )}
             {customersResponse.isSuccess && employeesResponse.isSuccess && (
-                <ProjectForm
-                    customers={customersResponse.data}
-                    employees={employeesResponse.data}
-                    project={undefined}
-                    projectId={undefined}
-                />
+                <CreateProjectForm customers={customersResponse.data} employees={employeesResponse.data} />
             )}
         </Layout>
     );


### PR DESCRIPTION
The current `ProjectForm` actually wants to be two separate forms: The expression
```
<CreateProjectForm customers={customers} employees=(employees} />
```
makes much more sense without context than
```
<ProjectForm customers={customers} employees=(employees} project={undefined} projectId={undefined} />
```
I suggest all forms doing the basic CRUD should be `Create[X]Form` or `Edit[X]Form` accordingly. Refactored the project form and renamed the others.