### PR TITLE
refactor: parent agnostic forms

### DIFF
--- a/components/form/CustomerForm.tsx
+++ b/components/form/CustomerForm.tsx
@@ -1,22 +1,9 @@
-import {
-    FormControl,
-    FormLabel,
-    Input,
-    Modal,
-    Button,
-    useDisclosure,
-    ModalOverlay,
-    ModalHeader,
-    ModalCloseButton,
-    ModalContent,
-    ModalBody,
-    ModalFooter,
-    Box,
-} from '@chakra-ui/react';
+import { FormControl, FormLabel, Input, Button, Box } from '@chakra-ui/react';
 import React, { useState } from 'react';
-import ErrorAlert from '@/components/common/ErrorAlert';
 import { Customer } from '@/lib/types/apiTypes';
 import { useUpdateCustomers } from '@/lib/hooks/useCustomers';
+import ErrorAlert from '../common/ErrorAlert';
+import { FormBase } from '@/lib/types/forms';
 
 type CustomerFields = Partial<Customer>;
 
@@ -29,17 +16,17 @@ const validateCustomerFields = (fields: CustomerFields): Customer => {
     }
 };
 
-function CreateCustomerForm(): JSX.Element {
-    const [customerFields, setCustomerFields] = useState<CustomerFields>({});
-    const { isOpen, onOpen, onClose } = useDisclosure();
-    const [errorMessage, setErrorMessage] = useState<string>('');
-    const { postCustomer } = useUpdateCustomers();
+type CreateCustomerFormProps = FormBase;
 
-    const submitForm = async (e: React.MouseEvent) => {
-        e.preventDefault();
+export function CreateCustomerForm({ afterSubmit }: CreateCustomerFormProps): JSX.Element {
+    const [customerFields, setCustomerFields] = useState<CustomerFields>({});
+    const { postCustomer } = useUpdateCustomers();
+    const [errorMessage, setErrorMessage] = useState<string>('');
+
+    const onSubmit = async () => {
         try {
             await postCustomer(validateCustomerFields(customerFields));
-            onClose();
+            afterSubmit && afterSubmit();
         } catch (error) {
             setErrorMessage(`${error}`);
         }
@@ -47,58 +34,49 @@ function CreateCustomerForm(): JSX.Element {
 
     return (
         <>
-            <Button onClick={onOpen}>Add Customer</Button>
-            <Modal closeOnOverlayClick={false} isOpen={isOpen} onClose={onClose}>
-                <ModalOverlay />
-                <ModalContent>
-                    <ModalHeader>Add New Customer</ModalHeader>
-                    <ModalCloseButton />
-                    <ModalBody>
-                        <FormControl>
-                            <FormLabel>Customer Name</FormLabel>
-                            <Input
-                                placeholder="Customer Name"
-                                onChange={(e) =>
-                                    setCustomerFields({
-                                        ...customerFields,
-                                        name: e.target.value,
-                                    })
-                                }
-                            />
-                        </FormControl>
+            <div style={{ padding: '20px' }}>
+                <FormControl>
+                    <FormLabel>Customer Name</FormLabel>
+                    <Input
+                        placeholder="Customer Name"
+                        onChange={(e) =>
+                            setCustomerFields({
+                                ...customerFields,
+                                name: e.target.value,
+                            })
+                        }
+                    />
+                </FormControl>
 
-                        <FormControl mt={4}>
-                            <FormLabel>Description</FormLabel>
-                            <Input
-                                placeholder="Description"
-                                onChange={(e) =>
-                                    setCustomerFields({
-                                        ...customerFields,
-                                        description: e.target.value,
-                                    })
-                                }
-                            />
-                        </FormControl>
-                        {errorMessage ? (
-                            <>
-                                <ErrorAlert />
-                                <Box>{errorMessage}</Box>
-                            </>
-                        ) : null}
-                    </ModalBody>
-
-                    <ModalFooter>
-                        <Button colorScheme="blue" mr={3} onClick={submitForm}>
-                            Save
-                        </Button>
-                        <Button colorScheme="grey" variant="outline" onClick={onClose}>
-                            Cancel
-                        </Button>
-                    </ModalFooter>
-                </ModalContent>
-            </Modal>
+                <FormControl mt={4}>
+                    <FormLabel>Description</FormLabel>
+                    <Input
+                        placeholder="Description"
+                        onChange={(e) =>
+                            setCustomerFields({
+                                ...customerFields,
+                                description: e.target.value,
+                            })
+                        }
+                    />
+                </FormControl>
+            </div>
+            <div style={{ textAlign: 'right', padding: '20px' }}>
+                <Button colorScheme="blue" mr={3} onClick={onSubmit}>
+                    Save
+                </Button>
+                <Button colorScheme="grey" variant="outline" onClick={() => null}>
+                    Cancel
+                </Button>
+            </div>
+            {errorMessage && (
+                <>
+                    <ErrorAlert />
+                    <Box>{errorMessage}</Box>
+                </>
+            )}
         </>
     );
 }
 
-export default CreateCustomerForm;
+export default CreateCustomerFormProps;

--- a/components/form/TaskForm.tsx
+++ b/components/form/TaskForm.tsx
@@ -1,16 +1,18 @@
 import { useUpdateTasks } from '@/lib/hooks/useTasks';
 import { Project, Task } from '@/lib/types/apiTypes';
-import { FormControl, FormLabel, Input, FormErrorMessage, ModalFooter, Button, Box } from '@chakra-ui/react';
+import { FormBase } from '@/lib/types/forms';
+import { FormControl, FormLabel, Input, FormErrorMessage, Button, Box } from '@chakra-ui/react';
 import React, { useState } from 'react';
 import ErrorAlert from '../common/ErrorAlert';
 
 type TaskFields = Partial<Task> & { project: Project };
 
-const validateTaskFields = (fields: TaskFields): Task => {
-    const { name } = fields;
+const validateTaskFields = (fields: TaskFields, projectId: number): Task => {
+    const { name, project } = fields;
     if (name) {
         return {
             ...fields,
+            project: { ...project, id: projectId },
             name,
         };
     } else {
@@ -18,13 +20,12 @@ const validateTaskFields = (fields: TaskFields): Task => {
     }
 };
 
-interface TaskFormProps {
+type TaskFormProps = FormBase & {
     project: Project;
     projectId: number;
-    onClose: () => void;
-}
+};
 
-export function CreateTaskForm({ project, onClose }: TaskFormProps): JSX.Element {
+export function CreateTaskForm({ project, projectId, afterSubmit }: TaskFormProps): JSX.Element {
     const [taskFields, setTaskFields] = useState<TaskFields>({
         project: project,
     });
@@ -34,8 +35,8 @@ export function CreateTaskForm({ project, onClose }: TaskFormProps): JSX.Element
     const handleSubmit = async (e: React.MouseEvent) => {
         e.preventDefault();
         try {
-            await postTask(validateTaskFields(taskFields));
-            onClose();
+            await postTask(validateTaskFields(taskFields, projectId));
+            afterSubmit && afterSubmit();
         } catch (error) {
             setErrorMessage(`${error}`);
         }
@@ -43,39 +44,41 @@ export function CreateTaskForm({ project, onClose }: TaskFormProps): JSX.Element
 
     return (
         <>
-            <FormControl isInvalid={!taskFields.name} isRequired>
-                <FormLabel>Task Name</FormLabel>
-                <Input
-                    placeholder="Task Name"
-                    onChange={(e) =>
-                        setTaskFields({
-                            ...taskFields,
-                            name: e.target.value,
-                        })
-                    }
-                />
-                <FormErrorMessage>Task name cannot be empty.</FormErrorMessage>
-            </FormControl>
-            <FormControl>
-                <FormLabel>Description</FormLabel>
-                <Input
-                    placeholder="Description"
-                    onChange={(e) =>
-                        setTaskFields({
-                            ...taskFields,
-                            description: e.target.value,
-                        })
-                    }
-                />
-            </FormControl>
-            <ModalFooter>
+            <div style={{ padding: '20px' }}>
+                <FormControl isInvalid={!taskFields.name} isRequired>
+                    <FormLabel>Task Name</FormLabel>
+                    <Input
+                        placeholder="Task Name"
+                        onChange={(e) =>
+                            setTaskFields({
+                                ...taskFields,
+                                name: e.target.value,
+                            })
+                        }
+                    />
+                    <FormErrorMessage>Task name cannot be empty.</FormErrorMessage>
+                </FormControl>
+                <FormControl>
+                    <FormLabel>Description</FormLabel>
+                    <Input
+                        placeholder="Description"
+                        onChange={(e) =>
+                            setTaskFields({
+                                ...taskFields,
+                                description: e.target.value,
+                            })
+                        }
+                    />
+                </FormControl>
+            </div>
+            <div style={{ textAlign: 'right', padding: '20px' }}>
                 <Button colorScheme="blue" mr={3} onClick={handleSubmit}>
                     Submit
                 </Button>
-                <Button colorScheme="gray" onClick={onClose}>
+                <Button colorScheme="gray" onClick={afterSubmit}>
                     Cancel
                 </Button>
-            </ModalFooter>
+            </div>
             {errorMessage ? (
                 <>
                     <ErrorAlert />

--- a/components/form/TimesheetForm.tsx
+++ b/components/form/TimesheetForm.tsx
@@ -1,6 +1,7 @@
 import { useUpdateTimesheets } from '@/lib/hooks/useTimesheets';
 import { Employee, Project, Timesheet } from '@/lib/types/apiTypes';
-import { Box, Button, FormControl, FormErrorMessage, FormLabel, Input, ModalFooter, Select } from '@chakra-ui/react';
+import { FormBase } from '@/lib/types/forms';
+import { Box, Button, FormControl, FormErrorMessage, FormLabel, Input, Select } from '@chakra-ui/react';
 import React, { useState } from 'react';
 import ErrorAlert from '../common/ErrorAlert';
 
@@ -8,13 +9,13 @@ type TimesheetFields = Partial<Timesheet> & {
     project: Project;
 };
 
-const validateTimesheetFields = (fields: TimesheetFields): Timesheet => {
+const validateTimesheetFields = (fields: TimesheetFields, projectId: number): Timesheet => {
     const { name, project, employee } = fields;
     if (name && project && employee) {
         return {
             ...fields,
+            project: { ...project, id: projectId },
             name,
-            project,
             employee,
         };
     } else {
@@ -22,13 +23,13 @@ const validateTimesheetFields = (fields: TimesheetFields): Timesheet => {
     }
 };
 
-interface TimesheetFormProps {
+type TimesheetFormProps = FormBase & {
     project: Project;
+    projectId: number;
     employees: Employee[];
-    onClose: () => void;
-}
+};
 
-export function CreateTimesheetForm({ project, employees, onClose }: TimesheetFormProps): JSX.Element {
+export function CreateTimesheetForm({ project, projectId, employees, afterSubmit }: TimesheetFormProps): JSX.Element {
     const [timesheetFields, setTimesheetFields] = useState<TimesheetFields>({ project });
     const [errorMessage, setErrorMessage] = useState<string>('');
     const { postTimesheet } = useUpdateTimesheets();
@@ -49,8 +50,8 @@ export function CreateTimesheetForm({ project, employees, onClose }: TimesheetFo
     const submitTimesheet = async (e: React.MouseEvent) => {
         e.preventDefault();
         try {
-            await postTimesheet(validateTimesheetFields(timesheetFields));
-            onClose();
+            await postTimesheet(validateTimesheetFields(timesheetFields, projectId));
+            afterSubmit && afterSubmit();
         } catch (error) {
             setErrorMessage(`${error}`);
         }
@@ -61,63 +62,65 @@ export function CreateTimesheetForm({ project, employees, onClose }: TimesheetFo
 
     return (
         <>
-            <FormControl>
-                <FormLabel>User</FormLabel>
-                <Select onChange={setEmployee} placeholder="Select employee">
-                    {employees.map((employee, idx) => {
-                        return (
-                            <option key={idx} value={employee.id}>
-                                {`${employee.first_name} ${employee.last_name}`}
-                            </option>
-                        );
-                    })}
-                </Select>
-            </FormControl>
-            <FormControl>
-                <FormLabel>Timesheet Name</FormLabel>
-                <Input
-                    placeholder="Timesheet Name"
-                    onChange={(e) =>
-                        setTimesheetFields({
-                            ...timesheetFields,
-                            name: e.target.value,
-                        })
-                    }
-                />
-            </FormControl>
-            <FormControl>
-                <FormLabel>Description</FormLabel>
-                <Input
-                    placeholder="Description"
-                    onChange={(e) =>
-                        setTimesheetFields({
-                            ...timesheetFields,
-                            description: e.target.value,
-                        })
-                    }
-                />
-            </FormControl>
-            <FormControl isInvalid={invalidAllocation}>
-                <FormLabel>Allocation</FormLabel>
-                <Input
-                    placeholder="0"
-                    onChange={(e) =>
-                        setTimesheetFields({
-                            ...timesheetFields,
-                            allocation: parseInt(e.target.value),
-                        })
-                    }
-                />
-                <FormErrorMessage>Allocation needs to be between 1 and 100 %.</FormErrorMessage>
-            </FormControl>
-            <ModalFooter>
+            <div style={{ padding: '20px' }}>
+                <FormControl>
+                    <FormLabel>User</FormLabel>
+                    <Select onChange={setEmployee} placeholder="Select employee">
+                        {employees.map((employee, idx) => {
+                            return (
+                                <option key={idx} value={employee.id}>
+                                    {`${employee.first_name} ${employee.last_name}`}
+                                </option>
+                            );
+                        })}
+                    </Select>
+                </FormControl>
+                <FormControl>
+                    <FormLabel>Timesheet Name</FormLabel>
+                    <Input
+                        placeholder="Timesheet Name"
+                        onChange={(e) =>
+                            setTimesheetFields({
+                                ...timesheetFields,
+                                name: e.target.value,
+                            })
+                        }
+                    />
+                </FormControl>
+                <FormControl>
+                    <FormLabel>Description</FormLabel>
+                    <Input
+                        placeholder="Description"
+                        onChange={(e) =>
+                            setTimesheetFields({
+                                ...timesheetFields,
+                                description: e.target.value,
+                            })
+                        }
+                    />
+                </FormControl>
+                <FormControl isInvalid={invalidAllocation}>
+                    <FormLabel>Allocation</FormLabel>
+                    <Input
+                        placeholder="0"
+                        onChange={(e) =>
+                            setTimesheetFields({
+                                ...timesheetFields,
+                                allocation: parseInt(e.target.value),
+                            })
+                        }
+                    />
+                    <FormErrorMessage>Allocation needs to be between 1 and 100 %.</FormErrorMessage>
+                </FormControl>
+            </div>
+            <div style={{ textAlign: 'right', padding: '20px' }}>
                 <Button colorScheme="blue" mr={3} onClick={submitTimesheet}>
                     Submit
                 </Button>
-                <Button colorScheme="gray" onClick={onClose}>
+                <Button colorScheme="gray" onClick={afterSubmit}>
                     Cancel
                 </Button>
-            </ModalFooter>
+            </div>
             {errorMessage ? (
                 <>
                     <ErrorAlert />

--- a/components/table/TaskTable.tsx
+++ b/components/table/TaskTable.tsx
@@ -81,7 +81,8 @@ function TaskTable({ project, tasks }: TaskTableProps): JSX.Element {
                             <CreateTaskForm
                                 project={project}
                                 projectId={project.id}
-                                onClose={() => setDisplayNewTaskForm(false)}
+                                afterSubmit={() => setDisplayNewTaskForm(false)}
+                                onCancel={() => setDisplayNewTaskForm(false)}
                             />
                         </ModalContent>
                     </Modal>

--- a/components/table/TimesheetTable.tsx
+++ b/components/table/TimesheetTable.tsx
@@ -97,19 +97,22 @@ function TimesheetTable({ project, timesheets, employees }: TimesheetTableProps)
                     Add User
                 </Button>
             </Flex>
-
-            <Modal isOpen={displayNewTimesheetForm} onClose={() => setDisplayNewTimesheetForm(false)}>
-                <ModalOverlay />
-                <ModalContent px="0.5rem">
-                    <ModalHeader>Add user to project</ModalHeader>
-                    <CreateTimesheetForm
-                        project={project}
-                        employees={employees}
-                        onClose={() => setDisplayNewTimesheetForm(false)}
-                    />
-                    <ModalCloseButton />
-                </ModalContent>
-            </Modal>
+            {project.id && (
+                <Modal isOpen={displayNewTimesheetForm} onClose={() => setDisplayNewTimesheetForm(false)}>
+                    <ModalOverlay />
+                    <ModalContent px="0.5rem">
+                        <ModalHeader>Add user to project</ModalHeader>
+                        <CreateTimesheetForm
+                            project={project}
+                            projectId={project.id}
+                            employees={employees}
+                            afterSubmit={() => setDisplayNewTimesheetForm(false)}
+                            onCancel={() => setDisplayNewTimesheetForm(false)}
+                        />
+                        <ModalCloseButton />
+                    </ModalContent>
+                </Modal>
+            )}
         </Flex>
     );
 }

--- a/lib/types/forms.ts
+++ b/lib/types/forms.ts
@@ -1,0 +1,4 @@
+export type FormBase = {
+    afterSubmit?: () => void;
+    onCancel?: () => void;
+};

--- a/pages/projects/[id]/edit.tsx
+++ b/pages/projects/[id]/edit.tsx
@@ -11,19 +11,22 @@ import { useEmployees } from '@/lib/hooks/useEmployees';
 import { useProjectDetail } from '@/lib/hooks/useProjects';
 
 type Props = {
-    id: number;
+    projectId: number;
 };
 
-function EditProjectPage({ id }: Props): JSX.Element {
+function EditProjectPage({ projectId }: Props): JSX.Element {
+    const router = useRouter();
     const { customersResponse } = useCustomers();
     const { employeesResponse } = useEmployees();
-    const { projectDetailResponse } = useProjectDetail(id);
+    const { projectDetailResponse } = useProjectDetail(projectId);
 
     const errorMessage =
         (customersResponse.isError && customersResponse.errorMessage) ||
         (employeesResponse.isError && employeesResponse.errorMessage) ||
         (projectDetailResponse.isError && projectDetailResponse.errorMessage) ||
         '';
+
+    const redirectToProjectDetail = () => router.push(`/projects/${projectId}`);
 
     return (
         <Layout>
@@ -45,6 +48,8 @@ function EditProjectPage({ id }: Props): JSX.Element {
                         employees={employeesResponse.data}
                         project={projectDetailResponse.data}
                         projectId={projectDetailResponse.data.id}
+                        afterSubmit={redirectToProjectDetail}
+                        onCancel={redirectToProjectDetail}
                     />
                 )}
         </Layout>
@@ -54,7 +59,7 @@ function EditProjectPage({ id }: Props): JSX.Element {
 const Edit: NextPage = () => {
     const router = useRouter();
     const id = router.query.id as string | undefined;
-    return id ? <EditProjectPage id={Number(id)} /> : null;
+    return id ? <EditProjectPage projectId={Number(id)} /> : null;
 };
 
 export default Edit;

--- a/pages/projects/new.tsx
+++ b/pages/projects/new.tsx
@@ -7,8 +7,10 @@ import Loading from '@/components/common/Loading';
 import { useCustomers } from '@/lib/hooks/useCustomers';
 import { useEmployees } from '@/lib/hooks/useEmployees';
 import { CreateProjectForm } from '@/components/form/ProjectForm';
+import { useRouter } from 'next/router';
 
 const New: NextPage = () => {
+    const router = useRouter();
     const { customersResponse } = useCustomers();
     const { employeesResponse } = useEmployees();
 
@@ -16,6 +18,8 @@ const New: NextPage = () => {
         (customersResponse.isError && customersResponse.errorMessage) ||
         (employeesResponse.isError && employeesResponse.errorMessage) ||
         '';
+
+    const redirectToProjectList = () => router.push('/projects');
 
     return (
         <Layout>
@@ -27,7 +31,12 @@ const New: NextPage = () => {
                 <ErrorAlert title={errorMessage} message={errorMessage} />
             )}
             {customersResponse.isSuccess && employeesResponse.isSuccess && (
-                <CreateProjectForm customers={customersResponse.data} employees={employeesResponse.data} />
+                <CreateProjectForm
+                    customers={customersResponse.data}
+                    employees={employeesResponse.data}
+                    afterSubmit={redirectToProjectList}
+                    onCancel={redirectToProjectList}
+                />
             )}
         </Layout>
     );


### PR DESCRIPTION
Ideally it should be possible to render the forms `CreateClientForm`, `CreateTaskForm` and `CreateTimesheetForm` anywhere: They should have no idea whether the parent is a modal or something else. This promotes component reuse and makes these forms much more useful in the long term.

I suggest we introduce optional `afterSubmit` and `onCancel` functions to forms. They allow patterns like
```
<CreateTaskForm afterSubmit={ closeModal } onCancel={ closeModal } />
```
in the parent.

A future improvement is that `afterSubmit` returns the created item to allow `afterSubmit( ( createdItem ) => doSomething(createdItem))`. You could, for example, redirect to the URL of a newly created project with
```
afterSubmit((newlyCreatedProject) => router.push(`/projects/${newlyCreatedProject.id}`))
```
this will not be done here.