### PR TITLE
feat: mutate detail cache keys on update

### DIFF
--- a/lib/hooks/useProjects.ts
+++ b/lib/hooks/useProjects.ts
@@ -2,9 +2,13 @@ import useSWR, { useSWRConfig } from 'swr';
 import { Project } from '../types/apiTypes';
 import { get, post, put } from '../utils/fetch';
 import { ApiResponseType, swrToData } from '../types/swrUtil';
+import { useMatchMutate } from '../utils/matchMutate';
 
 const projectEndpointURL = `${process.env.NEXT_PUBLIC_API_URL}/project`;
 const projectIdEndpointURL = (id: number): string => `${process.env.NEXT_PUBLIC_API_URL}/project/${id}`;
+const projectIdEndpointCacheKey = (id: number): string => `/project/${id}`;
+
+const projectIdEndpointCacheKeyRegex = /^\/project\/([0-9]+)$/;
 
 interface ProjectList {
     projectsResponse: ApiResponseType<Project[]>;
@@ -24,21 +28,29 @@ export const useProjects = (): ProjectList => {
 };
 
 export const useProjectDetail = (id: number): ProjectDetail => {
-    const projectDetailResponse = swrToData(useSWR<Project, Error>(projectIdEndpointURL(id), get));
+    const projectDetailResponse = swrToData(
+        useSWR<Project, Error>(projectIdEndpointCacheKey(id), () => get(projectIdEndpointURL(id))),
+    );
     return { projectDetailResponse };
 };
 
 export const useUpdateProjects = (): UpdateProjects => {
     const { mutate } = useSWRConfig();
+    const matchMutate = useMatchMutate();
+
     const postProject = async (project: Project) => {
         const response = await post(projectEndpointURL, project);
         mutate(projectEndpointURL);
+        matchMutate(projectIdEndpointCacheKeyRegex);
         return response;
     };
+
     const putProject = async (project: Project) => {
         const response = await put(projectEndpointURL, project);
         mutate(projectEndpointURL);
+        matchMutate(projectIdEndpointCacheKeyRegex);
         return response;
     };
+
     return { postProject, putProject };
 };

--- a/lib/utils/matchMutate.js
+++ b/lib/utils/matchMutate.js
@@ -1,0 +1,21 @@
+import { useSWRConfig } from 'swr';
+
+export const useMatchMutate = () => {
+    const { cache, mutate } = useSWRConfig();
+    return (matcher, ...args) => {
+        if (!(cache instanceof Map)) {
+            throw new Error('matchMutate requires the cache provider to be a Map instance');
+        }
+
+        const keys = [];
+
+        for (const key of cache.keys()) {
+            if (matcher.test(key)) {
+                keys.push(key);
+            }
+        }
+
+        const mutations = keys.map((key) => mutate(key, ...args));
+        return Promise.all(mutations);
+    };
+};


### PR DESCRIPTION
## Implement match mutate

@oskarikerppo noticed a missing feature in the current hooks: If we perform `putProject`, any components that use data from `useProjectDetail` are not updated. This is because we don't mutate the correct cache keys in `useUpdateProject`-hook.

What seems to be the correct way to achieve this is to use [match mutate](https://github.com/three-consulting/epoc-frontend/security/dependabot/yarn.lock/node-fetch/open), to mutate all API keys that match a RegEx.