### PR TITLE
feat: various form improvements

### DIFF
--- a/components/form/CustomerForm.tsx
+++ b/components/form/CustomerForm.tsx
@@ -1,22 +1,9 @@
-import {
-    FormControl,
-    FormLabel,
-    Input,
-    Modal,
-    Button,
-    useDisclosure,
-    ModalOverlay,
-    ModalHeader,
-    ModalCloseButton,
-    ModalContent,
-    ModalBody,
-    ModalFooter,
-    Box,
-} from '@chakra-ui/react';
+import { FormControl, FormLabel, Input, Button, Box } from '@chakra-ui/react';
 import React, { useState } from 'react';
-import ErrorAlert from '@/components/common/ErrorAlert';
 import { Customer } from '@/lib/types/apiTypes';
 import { useUpdateCustomers } from '@/lib/hooks/useCustomers';
+import ErrorAlert from '../common/ErrorAlert';
+import { FormBase } from '@/lib/types/forms';
 
 type CustomerFields = Partial<Customer>;
 
@@ -29,17 +16,17 @@ const validateCustomerFields = (fields: CustomerFields): Customer => {
     }
 };
 
-function CreateCustomerForm(): JSX.Element {
-    const [customerFields, setCustomerFields] = useState<CustomerFields>({});
-    const { isOpen, onOpen, onClose } = useDisclosure();
-    const [errorMessage, setErrorMessage] = useState<string>('');
-    const { postCustomer } = useUpdateCustomers();
+type CreateCustomerFormProps = FormBase;
 
-    const submitForm = async (e: React.MouseEvent) => {
-        e.preventDefault();
+export function CreateCustomerForm({ afterSubmit }: CreateCustomerFormProps): JSX.Element {
+    const [customerFields, setCustomerFields] = useState<CustomerFields>({});
+    const { postCustomer } = useUpdateCustomers();
+    const [errorMessage, setErrorMessage] = useState<string>('');
+
+    const onSubmit = async () => {
         try {
             await postCustomer(validateCustomerFields(customerFields));
-            onClose();
+            afterSubmit && afterSubmit();
         } catch (error) {
             setErrorMessage(`${error}`);
         }
@@ -47,58 +34,49 @@ function CreateCustomerForm(): JSX.Element {
 
     return (
         <>
-            <Button onClick={onOpen}>Add Customer</Button>
-            <Modal closeOnOverlayClick={false} isOpen={isOpen} onClose={onClose}>
-                <ModalOverlay />
-                <ModalContent>
-                    <ModalHeader>Add New Customer</ModalHeader>
-                    <ModalCloseButton />
-                    <ModalBody>
-                        <FormControl>
-                            <FormLabel>Customer Name</FormLabel>
-                            <Input
-                                placeholder="Customer Name"
-                                onChange={(e) =>
-                                    setCustomerFields({
-                                        ...customerFields,
-                                        name: e.target.value,
-                                    })
-                                }
-                            />
-                        </FormControl>
+            <div style={{ padding: '20px' }}>
+                <FormControl>
+                    <FormLabel>Customer Name</FormLabel>
+                    <Input
+                        placeholder="Customer Name"
+                        onChange={(e) =>
+                            setCustomerFields({
+                                ...customerFields,
+                                name: e.target.value,
+                            })
+                        }
+                    />
+                </FormControl>
 
-                        <FormControl mt={4}>
-                            <FormLabel>Description</FormLabel>
-                            <Input
-                                placeholder="Description"
-                                onChange={(e) =>
-                                    setCustomerFields({
-                                        ...customerFields,
-                                        description: e.target.value,
-                                    })
-                                }
-                            />
-                        </FormControl>
-                        {errorMessage ? (
-                            <>
-                                <ErrorAlert />
-                                <Box>{errorMessage}</Box>
-                            </>
-                        ) : null}
-                    </ModalBody>
-
-                    <ModalFooter>
-                        <Button colorScheme="blue" mr={3} onClick={submitForm}>
-                            Save
-                        </Button>
-                        <Button colorScheme="grey" variant="outline" onClick={onClose}>
-                            Cancel
-                        </Button>
-                    </ModalFooter>
-                </ModalContent>
-            </Modal>
+                <FormControl mt={4}>
+                    <FormLabel>Description</FormLabel>
+                    <Input
+                        placeholder="Description"
+                        onChange={(e) =>
+                            setCustomerFields({
+                                ...customerFields,
+                                description: e.target.value,
+                            })
+                        }
+                    />
+                </FormControl>
+            </div>
+            <div style={{ textAlign: 'right', padding: '20px' }}>
+                <Button colorScheme="blue" mr={3} onClick={onSubmit}>
+                    Save
+                </Button>
+                <Button colorScheme="grey" variant="outline" onClick={() => null}>
+                    Cancel
+                </Button>
+            </div>
+            {errorMessage && (
+                <>
+                    <ErrorAlert />
+                    <Box>{errorMessage}</Box>
+                </>
+            )}
         </>
     );
 }
 
-export default CreateCustomerForm;
+export default CreateCustomerFormProps;

--- a/components/form/CustomerForm.tsx
+++ b/components/form/CustomerForm.tsx
@@ -15,17 +15,17 @@ const validateCustomerFields = (fields: CustomerFields): Customer => {
     }
 };
 
-type CreateCustomerFormProps = FormBase;
+type CreateCustomerFormProps = FormBase<Customer>;
 
 export function CreateCustomerForm({ afterSubmit }: CreateCustomerFormProps): JSX.Element {
     const [customerFields, setCustomerFields] = useState<CustomerFields>({});
     const { postCustomer } = useUpdateCustomers();
 
     const onSubmit = async () => {
-        await postCustomer(validateCustomerFields(customerFields), () => {
+        const newCustomer = await postCustomer(validateCustomerFields(customerFields), () => {
             undefined;
         });
-        afterSubmit && afterSubmit();
+        afterSubmit && afterSubmit(newCustomer);
     };
 
     return (

--- a/components/form/CustomerForm.tsx
+++ b/components/form/CustomerForm.tsx
@@ -1,8 +1,7 @@
-import { FormControl, FormLabel, Input, Button, Box } from '@chakra-ui/react';
+import { FormControl, FormLabel, Input, Button } from '@chakra-ui/react';
 import React, { useState } from 'react';
 import { Customer } from '@/lib/types/apiTypes';
 import { useUpdateCustomers } from '@/lib/hooks/useCustomers';
-import ErrorAlert from '../common/ErrorAlert';
 import { FormBase } from '@/lib/types/forms';
 
 type CustomerFields = Partial<Customer>;
@@ -21,15 +20,12 @@ type CreateCustomerFormProps = FormBase;
 export function CreateCustomerForm({ afterSubmit }: CreateCustomerFormProps): JSX.Element {
     const [customerFields, setCustomerFields] = useState<CustomerFields>({});
     const { postCustomer } = useUpdateCustomers();
-    const [errorMessage, setErrorMessage] = useState<string>('');
 
     const onSubmit = async () => {
-        try {
-            await postCustomer(validateCustomerFields(customerFields));
-            afterSubmit && afterSubmit();
-        } catch (error) {
-            setErrorMessage(`${error}`);
-        }
+        await postCustomer(validateCustomerFields(customerFields), () => {
+            undefined;
+        });
+        afterSubmit && afterSubmit();
     };
 
     return (
@@ -69,12 +65,6 @@ export function CreateCustomerForm({ afterSubmit }: CreateCustomerFormProps): JS
                     Cancel
                 </Button>
             </div>
-            {errorMessage && (
-                <>
-                    <ErrorAlert />
-                    <Box>{errorMessage}</Box>
-                </>
-            )}
         </>
     );
 }

--- a/components/form/ProjectForm.tsx
+++ b/components/form/ProjectForm.tsx
@@ -179,7 +179,7 @@ function ProjectForm({ project: projectOrNull, customers, employees, onSubmit, o
     );
 }
 
-type CreateProjectFormProps = FormBase & {
+type CreateProjectFormProps = FormBase<Project> & {
     employees: Employee[];
     customers: Customer[];
 };
@@ -187,10 +187,10 @@ type CreateProjectFormProps = FormBase & {
 export const CreateProjectForm = (props: CreateProjectFormProps): JSX.Element => {
     const { postProject } = useUpdateProjects();
     const onSubmit = async (project: Project) => {
-        await postProject(project, () => {
+        const newProject = await postProject(project, () => {
             undefined;
         });
-        props.afterSubmit && props.afterSubmit();
+        props.afterSubmit && props.afterSubmit(newProject);
     };
     return <ProjectForm {...props} project={undefined} onSubmit={onSubmit} />;
 };
@@ -203,10 +203,10 @@ type EditProjectFormProps = CreateProjectFormProps & {
 export const EditProjectForm = (props: EditProjectFormProps): JSX.Element => {
     const { putProject } = useUpdateProjects();
     const onSubmit = async (project: Project) => {
-        await putProject(project, () => {
+        const updatedProject = await putProject(project, () => {
             undefined;
         });
-        props.afterSubmit && props.afterSubmit();
+        props.afterSubmit && props.afterSubmit(updatedProject);
     };
     return <ProjectForm {...props} onSubmit={onSubmit} />;
 };

--- a/components/form/ProjectForm.tsx
+++ b/components/form/ProjectForm.tsx
@@ -187,7 +187,9 @@ type CreateProjectFormProps = FormBase & {
 export const CreateProjectForm = (props: CreateProjectFormProps): JSX.Element => {
     const { postProject } = useUpdateProjects();
     const onSubmit = async (project: Project) => {
-        await postProject(project);
+        await postProject(project, () => {
+            undefined;
+        });
         props.afterSubmit && props.afterSubmit();
     };
     return <ProjectForm {...props} project={undefined} onSubmit={onSubmit} />;
@@ -201,7 +203,9 @@ type EditProjectFormProps = CreateProjectFormProps & {
 export const EditProjectForm = (props: EditProjectFormProps): JSX.Element => {
     const { putProject } = useUpdateProjects();
     const onSubmit = async (project: Project) => {
-        await putProject(project);
+        await putProject(project, () => {
+            undefined;
+        });
         props.afterSubmit && props.afterSubmit();
     };
     return <ProjectForm {...props} onSubmit={onSubmit} />;

--- a/components/form/TaskForm.tsx
+++ b/components/form/TaskForm.tsx
@@ -20,28 +20,24 @@ const validateTaskFields = (fields: TaskFields, projectId: number): Task => {
     }
 };
 
-type TaskFormProps = FormBase & {
+type TaskFormProps = FormBase<Task> & {
     project: Project;
     projectId: number;
 };
 
-export function CreateTaskForm({ project, projectId, afterSubmit }: TaskFormProps): JSX.Element {
+export function CreateTaskForm({ project, projectId, afterSubmit, onCancel }: TaskFormProps): JSX.Element {
     const [taskFields, setTaskFields] = useState<TaskFields>({
         project: project,
     });
-    const [errorMessage, setErrorMessage] = useState<string>('');
+    const [errorMessage] = useState<string>('');
     const { postTask } = useUpdateTasks();
 
     const handleSubmit = async (e: React.MouseEvent) => {
         e.preventDefault();
-        try {
-            await postTask(validateTaskFields(taskFields, projectId), () => {
-                undefined;
-            });
-            afterSubmit && afterSubmit();
-        } catch (error) {
-            setErrorMessage(`${error}`);
-        }
+        const newTask = await postTask(validateTaskFields(taskFields, projectId), () => {
+            undefined;
+        });
+        afterSubmit && afterSubmit(newTask);
     };
 
     return (
@@ -77,7 +73,7 @@ export function CreateTaskForm({ project, projectId, afterSubmit }: TaskFormProp
                 <Button colorScheme="blue" mr={3} onClick={handleSubmit}>
                     Submit
                 </Button>
-                <Button colorScheme="gray" onClick={afterSubmit}>
+                <Button colorScheme="gray" onClick={onCancel}>
                     Cancel
                 </Button>
             </div>

--- a/components/form/TaskForm.tsx
+++ b/components/form/TaskForm.tsx
@@ -29,15 +29,20 @@ export function CreateTaskForm({ project, projectId, afterSubmit, onCancel }: Ta
     const [taskFields, setTaskFields] = useState<TaskFields>({
         project: project,
     });
-    const [errorMessage] = useState<string>('');
     const { postTask } = useUpdateTasks();
 
-    const handleSubmit = async (e: React.MouseEvent) => {
+    const [errorMessage, setErrorMessage] = useState<string>('');
+    const errorHandler = (error: Error) => setErrorMessage(`${error}`);
+
+    const onSubmit = async (e: React.MouseEvent) => {
         e.preventDefault();
-        const newTask = await postTask(validateTaskFields(taskFields, projectId), () => {
-            undefined;
-        });
-        afterSubmit && afterSubmit(newTask);
+        try {
+            const task = validateTaskFields(taskFields, projectId);
+            const newTask = await postTask(task, errorHandler);
+            afterSubmit && afterSubmit(newTask);
+        } catch (error) {
+            errorHandler(error as Error);
+        }
     };
 
     return (
@@ -70,19 +75,19 @@ export function CreateTaskForm({ project, projectId, afterSubmit, onCancel }: Ta
                 </FormControl>
             </div>
             <div style={{ textAlign: 'right', padding: '20px' }}>
-                <Button colorScheme="blue" mr={3} onClick={handleSubmit}>
+                <Button colorScheme="blue" mr={3} onClick={onSubmit}>
                     Submit
                 </Button>
                 <Button colorScheme="gray" onClick={onCancel}>
                     Cancel
                 </Button>
             </div>
-            {errorMessage ? (
+            {errorMessage && (
                 <>
                     <ErrorAlert />
                     <Box>{errorMessage}</Box>
                 </>
-            ) : null}
+            )}
         </>
     );
 }

--- a/components/form/TaskForm.tsx
+++ b/components/form/TaskForm.tsx
@@ -35,7 +35,9 @@ export function CreateTaskForm({ project, projectId, afterSubmit }: TaskFormProp
     const handleSubmit = async (e: React.MouseEvent) => {
         e.preventDefault();
         try {
-            await postTask(validateTaskFields(taskFields, projectId));
+            await postTask(validateTaskFields(taskFields, projectId), () => {
+                undefined;
+            });
             afterSubmit && afterSubmit();
         } catch (error) {
             setErrorMessage(`${error}`);

--- a/components/form/TaskForm.tsx
+++ b/components/form/TaskForm.tsx
@@ -1,16 +1,18 @@
 import { useUpdateTasks } from '@/lib/hooks/useTasks';
 import { Project, Task } from '@/lib/types/apiTypes';
-import { FormControl, FormLabel, Input, FormErrorMessage, ModalFooter, Button, Box } from '@chakra-ui/react';
+import { FormBase } from '@/lib/types/forms';
+import { FormControl, FormLabel, Input, FormErrorMessage, Button, Box } from '@chakra-ui/react';
 import React, { useState } from 'react';
 import ErrorAlert from '../common/ErrorAlert';
 
 type TaskFields = Partial<Task> & { project: Project };
 
-const validateTaskFields = (fields: TaskFields): Task => {
-    const { name } = fields;
+const validateTaskFields = (fields: TaskFields, projectId: number): Task => {
+    const { name, project } = fields;
     if (name) {
         return {
             ...fields,
+            project: { ...project, id: projectId },
             name,
         };
     } else {
@@ -18,13 +20,12 @@ const validateTaskFields = (fields: TaskFields): Task => {
     }
 };
 
-interface TaskFormProps {
+type TaskFormProps = FormBase & {
     project: Project;
     projectId: number;
-    onClose: () => void;
-}
+};
 
-export function CreateTaskForm({ project, onClose }: TaskFormProps): JSX.Element {
+export function CreateTaskForm({ project, projectId, afterSubmit }: TaskFormProps): JSX.Element {
     const [taskFields, setTaskFields] = useState<TaskFields>({
         project: project,
     });
@@ -34,8 +35,8 @@ export function CreateTaskForm({ project, onClose }: TaskFormProps): JSX.Element
     const handleSubmit = async (e: React.MouseEvent) => {
         e.preventDefault();
         try {
-            await postTask(validateTaskFields(taskFields));
-            onClose();
+            await postTask(validateTaskFields(taskFields, projectId));
+            afterSubmit && afterSubmit();
         } catch (error) {
             setErrorMessage(`${error}`);
         }
@@ -43,39 +44,41 @@ export function CreateTaskForm({ project, onClose }: TaskFormProps): JSX.Element
 
     return (
         <>
-            <FormControl isInvalid={!taskFields.name} isRequired>
-                <FormLabel>Task Name</FormLabel>
-                <Input
-                    placeholder="Task Name"
-                    onChange={(e) =>
-                        setTaskFields({
-                            ...taskFields,
-                            name: e.target.value,
-                        })
-                    }
-                />
-                <FormErrorMessage>Task name cannot be empty.</FormErrorMessage>
-            </FormControl>
-            <FormControl>
-                <FormLabel>Description</FormLabel>
-                <Input
-                    placeholder="Description"
-                    onChange={(e) =>
-                        setTaskFields({
-                            ...taskFields,
-                            description: e.target.value,
-                        })
-                    }
-                />
-            </FormControl>
-            <ModalFooter>
+            <div style={{ padding: '20px' }}>
+                <FormControl isInvalid={!taskFields.name} isRequired>
+                    <FormLabel>Task Name</FormLabel>
+                    <Input
+                        placeholder="Task Name"
+                        onChange={(e) =>
+                            setTaskFields({
+                                ...taskFields,
+                                name: e.target.value,
+                            })
+                        }
+                    />
+                    <FormErrorMessage>Task name cannot be empty.</FormErrorMessage>
+                </FormControl>
+                <FormControl>
+                    <FormLabel>Description</FormLabel>
+                    <Input
+                        placeholder="Description"
+                        onChange={(e) =>
+                            setTaskFields({
+                                ...taskFields,
+                                description: e.target.value,
+                            })
+                        }
+                    />
+                </FormControl>
+            </div>
+            <div style={{ textAlign: 'right', padding: '20px' }}>
                 <Button colorScheme="blue" mr={3} onClick={handleSubmit}>
                     Submit
                 </Button>
-                <Button colorScheme="gray" onClick={onClose}>
+                <Button colorScheme="gray" onClick={afterSubmit}>
                     Cancel
                 </Button>
-            </ModalFooter>
+            </div>
             {errorMessage ? (
                 <>
                     <ErrorAlert />

--- a/components/form/TimesheetForm.tsx
+++ b/components/form/TimesheetForm.tsx
@@ -1,6 +1,7 @@
 import { useUpdateTimesheets } from '@/lib/hooks/useTimesheets';
 import { Employee, Project, Timesheet } from '@/lib/types/apiTypes';
-import { Box, Button, FormControl, FormErrorMessage, FormLabel, Input, ModalFooter, Select } from '@chakra-ui/react';
+import { FormBase } from '@/lib/types/forms';
+import { Box, Button, FormControl, FormErrorMessage, FormLabel, Input, Select } from '@chakra-ui/react';
 import React, { useState } from 'react';
 import ErrorAlert from '../common/ErrorAlert';
 
@@ -8,13 +9,13 @@ type TimesheetFields = Partial<Timesheet> & {
     project: Project;
 };
 
-const validateTimesheetFields = (fields: TimesheetFields): Timesheet => {
+const validateTimesheetFields = (fields: TimesheetFields, projectId: number): Timesheet => {
     const { name, project, employee } = fields;
     if (name && project && employee) {
         return {
             ...fields,
+            project: { ...project, id: projectId },
             name,
-            project,
             employee,
         };
     } else {
@@ -22,13 +23,13 @@ const validateTimesheetFields = (fields: TimesheetFields): Timesheet => {
     }
 };
 
-interface TimesheetFormProps {
+type TimesheetFormProps = FormBase & {
     project: Project;
+    projectId: number;
     employees: Employee[];
-    onClose: () => void;
-}
+};
 
-export function CreateTimesheetForm({ project, employees, onClose }: TimesheetFormProps): JSX.Element {
+export function CreateTimesheetForm({ project, projectId, employees, afterSubmit }: TimesheetFormProps): JSX.Element {
     const [timesheetFields, setTimesheetFields] = useState<TimesheetFields>({ project });
     const [errorMessage, setErrorMessage] = useState<string>('');
     const { postTimesheet } = useUpdateTimesheets();
@@ -49,8 +50,8 @@ export function CreateTimesheetForm({ project, employees, onClose }: TimesheetFo
     const submitTimesheet = async (e: React.MouseEvent) => {
         e.preventDefault();
         try {
-            await postTimesheet(validateTimesheetFields(timesheetFields));
-            onClose();
+            await postTimesheet(validateTimesheetFields(timesheetFields, projectId));
+            afterSubmit && afterSubmit();
         } catch (error) {
             setErrorMessage(`${error}`);
         }
@@ -61,63 +62,65 @@ export function CreateTimesheetForm({ project, employees, onClose }: TimesheetFo
 
     return (
         <>
-            <FormControl>
-                <FormLabel>User</FormLabel>
-                <Select onChange={setEmployee} placeholder="Select employee">
-                    {employees.map((employee, idx) => {
-                        return (
-                            <option key={idx} value={employee.id}>
-                                {`${employee.first_name} ${employee.last_name}`}
-                            </option>
-                        );
-                    })}
-                </Select>
-            </FormControl>
-            <FormControl>
-                <FormLabel>Timesheet Name</FormLabel>
-                <Input
-                    placeholder="Timesheet Name"
-                    onChange={(e) =>
-                        setTimesheetFields({
-                            ...timesheetFields,
-                            name: e.target.value,
-                        })
-                    }
-                />
-            </FormControl>
-            <FormControl>
-                <FormLabel>Description</FormLabel>
-                <Input
-                    placeholder="Description"
-                    onChange={(e) =>
-                        setTimesheetFields({
-                            ...timesheetFields,
-                            description: e.target.value,
-                        })
-                    }
-                />
-            </FormControl>
-            <FormControl isInvalid={invalidAllocation}>
-                <FormLabel>Allocation</FormLabel>
-                <Input
-                    placeholder="0"
-                    onChange={(e) =>
-                        setTimesheetFields({
-                            ...timesheetFields,
-                            allocation: parseInt(e.target.value),
-                        })
-                    }
-                />
-                <FormErrorMessage>Allocation needs to be between 1 and 100 %.</FormErrorMessage>
-            </FormControl>
-            <ModalFooter>
+            <div style={{ padding: '20px' }}>
+                <FormControl>
+                    <FormLabel>User</FormLabel>
+                    <Select onChange={setEmployee} placeholder="Select employee">
+                        {employees.map((employee, idx) => {
+                            return (
+                                <option key={idx} value={employee.id}>
+                                    {`${employee.first_name} ${employee.last_name}`}
+                                </option>
+                            );
+                        })}
+                    </Select>
+                </FormControl>
+                <FormControl>
+                    <FormLabel>Timesheet Name</FormLabel>
+                    <Input
+                        placeholder="Timesheet Name"
+                        onChange={(e) =>
+                            setTimesheetFields({
+                                ...timesheetFields,
+                                name: e.target.value,
+                            })
+                        }
+                    />
+                </FormControl>
+                <FormControl>
+                    <FormLabel>Description</FormLabel>
+                    <Input
+                        placeholder="Description"
+                        onChange={(e) =>
+                            setTimesheetFields({
+                                ...timesheetFields,
+                                description: e.target.value,
+                            })
+                        }
+                    />
+                </FormControl>
+                <FormControl isInvalid={invalidAllocation}>
+                    <FormLabel>Allocation</FormLabel>
+                    <Input
+                        placeholder="0"
+                        onChange={(e) =>
+                            setTimesheetFields({
+                                ...timesheetFields,
+                                allocation: parseInt(e.target.value),
+                            })
+                        }
+                    />
+                    <FormErrorMessage>Allocation needs to be between 1 and 100 %.</FormErrorMessage>
+                </FormControl>
+            </div>
+            <div style={{ textAlign: 'right', padding: '20px' }}>
                 <Button colorScheme="blue" mr={3} onClick={submitTimesheet}>
                     Submit
                 </Button>
-                <Button colorScheme="gray" onClick={onClose}>
+                <Button colorScheme="gray" onClick={afterSubmit}>
                     Cancel
                 </Button>
-            </ModalFooter>
+            </div>
             {errorMessage ? (
                 <>
                     <ErrorAlert />

--- a/components/form/TimesheetForm.tsx
+++ b/components/form/TimesheetForm.tsx
@@ -23,15 +23,21 @@ const validateTimesheetFields = (fields: TimesheetFields, projectId: number): Ti
     }
 };
 
-type TimesheetFormProps = FormBase & {
+type TimesheetFormProps = FormBase<Timesheet> & {
     project: Project;
     projectId: number;
     employees: Employee[];
 };
 
-export function CreateTimesheetForm({ project, projectId, employees, afterSubmit }: TimesheetFormProps): JSX.Element {
+export function CreateTimesheetForm({
+    project,
+    projectId,
+    employees,
+    afterSubmit,
+    onCancel,
+}: TimesheetFormProps): JSX.Element {
     const [timesheetFields, setTimesheetFields] = useState<TimesheetFields>({ project });
-    const [errorMessage, setErrorMessage] = useState<string>('');
+    const [errorMessage] = useState<string>('');
     const { postTimesheet } = useUpdateTimesheets();
 
     const setEmployee = (e: React.FormEvent<HTMLSelectElement>) => {
@@ -49,14 +55,10 @@ export function CreateTimesheetForm({ project, projectId, employees, afterSubmit
 
     const submitTimesheet = async (e: React.MouseEvent) => {
         e.preventDefault();
-        try {
-            await postTimesheet(validateTimesheetFields(timesheetFields, projectId), () => {
-                undefined;
-            });
-            afterSubmit && afterSubmit();
-        } catch (error) {
-            setErrorMessage(`${error}`);
-        }
+        const newTimesheet = await postTimesheet(validateTimesheetFields(timesheetFields, projectId), () => {
+            undefined;
+        });
+        afterSubmit && afterSubmit(newTimesheet);
     };
 
     const invalidAllocation =
@@ -119,7 +121,7 @@ export function CreateTimesheetForm({ project, projectId, employees, afterSubmit
                 <Button colorScheme="blue" mr={3} onClick={submitTimesheet}>
                     Submit
                 </Button>
-                <Button colorScheme="gray" onClick={afterSubmit}>
+                <Button colorScheme="gray" onCancel={onCancel}>
                     Cancel
                 </Button>
             </div>

--- a/components/form/TimesheetForm.tsx
+++ b/components/form/TimesheetForm.tsx
@@ -50,7 +50,9 @@ export function CreateTimesheetForm({ project, projectId, employees, afterSubmit
     const submitTimesheet = async (e: React.MouseEvent) => {
         e.preventDefault();
         try {
-            await postTimesheet(validateTimesheetFields(timesheetFields, projectId));
+            await postTimesheet(validateTimesheetFields(timesheetFields, projectId), () => {
+                undefined;
+            });
             afterSubmit && afterSubmit();
         } catch (error) {
             setErrorMessage(`${error}`);

--- a/components/form/TimesheetForm.tsx
+++ b/components/form/TimesheetForm.tsx
@@ -37,8 +37,10 @@ export function CreateTimesheetForm({
     onCancel,
 }: TimesheetFormProps): JSX.Element {
     const [timesheetFields, setTimesheetFields] = useState<TimesheetFields>({ project });
-    const [errorMessage] = useState<string>('');
     const { postTimesheet } = useUpdateTimesheets();
+
+    const [errorMessage, setErrorMessage] = useState<string>('');
+    const errorHandler = (error: Error) => setErrorMessage(`${error}`);
 
     const setEmployee = (e: React.FormEvent<HTMLSelectElement>) => {
         e.preventDefault();
@@ -53,12 +55,15 @@ export function CreateTimesheetForm({
         }
     };
 
-    const submitTimesheet = async (e: React.MouseEvent) => {
+    const onSubmit = async (e: React.MouseEvent) => {
         e.preventDefault();
-        const newTimesheet = await postTimesheet(validateTimesheetFields(timesheetFields, projectId), () => {
-            undefined;
-        });
-        afterSubmit && afterSubmit(newTimesheet);
+        try {
+            const timesheet = validateTimesheetFields(timesheetFields, projectId);
+            const newTimesheet = await postTimesheet(timesheet, errorHandler);
+            afterSubmit && afterSubmit(newTimesheet);
+        } catch (error) {
+            errorHandler(error as Error);
+        }
     };
 
     const invalidAllocation =
@@ -118,19 +123,19 @@ export function CreateTimesheetForm({
                 </FormControl>
             </div>
             <div style={{ textAlign: 'right', padding: '20px' }}>
-                <Button colorScheme="blue" mr={3} onClick={submitTimesheet}>
+                <Button colorScheme="blue" mr={3} onClick={onSubmit}>
                     Submit
                 </Button>
-                <Button colorScheme="gray" onCancel={onCancel}>
+                <Button colorScheme="gray" onClick={onCancel}>
                     Cancel
                 </Button>
             </div>
-            {errorMessage ? (
+            {errorMessage && (
                 <>
                     <ErrorAlert />
                     <Box>{errorMessage}</Box>
                 </>
-            ) : null}
+            )}
         </>
     );
 }

--- a/components/table/TaskTable.tsx
+++ b/components/table/TaskTable.tsx
@@ -5,6 +5,7 @@ import { Box, Flex, Heading } from '@chakra-ui/layout';
 import { Modal, ModalCloseButton, ModalContent, ModalHeader, ModalOverlay, Tbody } from '@chakra-ui/react';
 import { Table, Td, Th, Thead, Tr } from '@chakra-ui/table';
 import React, { useState } from 'react';
+import ErrorAlert from '../common/ErrorAlert';
 import { CreateTaskForm } from '../form/TaskForm';
 
 interface TaskRowProps {
@@ -13,17 +14,26 @@ interface TaskRowProps {
 
 function TaskRow({ task }: TaskRowProps): JSX.Element {
     const { putTask } = useUpdateTasks();
-    const archiveTask = () =>
-        putTask({ ...task, status: 'ARCHIVED' }, () => {
-            undefined;
-        });
+
+    const [errorMessage, setErrorMessage] = useState<string>('');
+    const errorHandler = (error: Error) => setErrorMessage(`${error}`);
+
+    const archiveTask = () => putTask({ ...task, status: 'ARCHIVED' }, errorHandler);
     return (
-        <Tr _hover={{ backgroundColor: 'gray.200', cursor: 'pointer' }}>
-            <Td>{task.name}</Td>
-            <Td>
-                <Button onClick={archiveTask}>x</Button>
-            </Td>
-        </Tr>
+        <>
+            <Tr _hover={{ backgroundColor: 'gray.200', cursor: 'pointer' }}>
+                <Td>{task.name}</Td>
+                <Td>
+                    <Button onClick={archiveTask}>x</Button>
+                </Td>
+            </Tr>
+            {errorMessage && (
+                <>
+                    <ErrorAlert />
+                    <Box>{errorMessage}</Box>
+                </>
+            )}
+        </>
     );
 }
 
@@ -84,7 +94,7 @@ function TaskTable({ project, tasks }: TaskTableProps): JSX.Element {
                             <CreateTaskForm
                                 project={project}
                                 projectId={project.id}
-                                afterSubmit={() => setDisplayNewTaskForm(false)}
+                                afterSubmit={(task) => (task ? setDisplayNewTaskForm(false) : undefined)}
                                 onCancel={() => setDisplayNewTaskForm(false)}
                             />
                         </ModalContent>

--- a/components/table/TaskTable.tsx
+++ b/components/table/TaskTable.tsx
@@ -13,7 +13,10 @@ interface TaskRowProps {
 
 function TaskRow({ task }: TaskRowProps): JSX.Element {
     const { putTask } = useUpdateTasks();
-    const archiveTask = () => putTask({ ...task, status: 'ARCHIVED' });
+    const archiveTask = () =>
+        putTask({ ...task, status: 'ARCHIVED' }, () => {
+            undefined;
+        });
     return (
         <Tr _hover={{ backgroundColor: 'gray.200', cursor: 'pointer' }}>
             <Td>{task.name}</Td>

--- a/components/table/TaskTable.tsx
+++ b/components/table/TaskTable.tsx
@@ -81,7 +81,8 @@ function TaskTable({ project, tasks }: TaskTableProps): JSX.Element {
                             <CreateTaskForm
                                 project={project}
                                 projectId={project.id}
-                                onClose={() => setDisplayNewTaskForm(false)}
+                                afterSubmit={() => setDisplayNewTaskForm(false)}
+                                onCancel={() => setDisplayNewTaskForm(false)}
                             />
                         </ModalContent>
                     </Modal>

--- a/components/table/TimesheetTable.tsx
+++ b/components/table/TimesheetTable.tsx
@@ -97,19 +97,22 @@ function TimesheetTable({ project, timesheets, employees }: TimesheetTableProps)
                     Add User
                 </Button>
             </Flex>
-
-            <Modal isOpen={displayNewTimesheetForm} onClose={() => setDisplayNewTimesheetForm(false)}>
-                <ModalOverlay />
-                <ModalContent px="0.5rem">
-                    <ModalHeader>Add user to project</ModalHeader>
-                    <CreateTimesheetForm
-                        project={project}
-                        employees={employees}
-                        onClose={() => setDisplayNewTimesheetForm(false)}
-                    />
-                    <ModalCloseButton />
-                </ModalContent>
-            </Modal>
+            {project.id && (
+                <Modal isOpen={displayNewTimesheetForm} onClose={() => setDisplayNewTimesheetForm(false)}>
+                    <ModalOverlay />
+                    <ModalContent px="0.5rem">
+                        <ModalHeader>Add user to project</ModalHeader>
+                        <CreateTimesheetForm
+                            project={project}
+                            projectId={project.id}
+                            employees={employees}
+                            afterSubmit={() => setDisplayNewTimesheetForm(false)}
+                            onCancel={() => setDisplayNewTimesheetForm(false)}
+                        />
+                        <ModalCloseButton />
+                    </ModalContent>
+                </Modal>
+            )}
         </Flex>
     );
 }

--- a/components/table/TimesheetTable.tsx
+++ b/components/table/TimesheetTable.tsx
@@ -12,18 +12,14 @@ interface TimesheetRowProps {
     timesheet: Timesheet;
 }
 function TimesheetRow({ timesheet }: TimesheetRowProps): JSX.Element {
-    const [errorMessage, setErrorMessage] = useState<string>('');
     const { putTimesheet } = useUpdateTimesheets();
+
+    const [errorMessage, setErrorMessage] = useState<string>('');
+    const errorHandler = (error: Error) => setErrorMessage(`${error}`);
 
     const archiveTimesheet = async (timesheet: Timesheet, e: React.MouseEvent) => {
         e.preventDefault();
-        try {
-            await putTimesheet({ ...timesheet, status: 'ARCHIVED' }, () => {
-                undefined;
-            });
-        } catch (error) {
-            setErrorMessage(`${error}`);
-        }
+        await putTimesheet({ ...timesheet, status: 'ARCHIVED' }, errorHandler);
     };
 
     return (
@@ -108,7 +104,7 @@ function TimesheetTable({ project, timesheets, employees }: TimesheetTableProps)
                             project={project}
                             projectId={project.id}
                             employees={employees}
-                            afterSubmit={() => setDisplayNewTimesheetForm(false)}
+                            afterSubmit={(timesheet) => (timesheet ? setDisplayNewTimesheetForm(false) : undefined)}
                             onCancel={() => setDisplayNewTimesheetForm(false)}
                         />
                         <ModalCloseButton />

--- a/components/table/TimesheetTable.tsx
+++ b/components/table/TimesheetTable.tsx
@@ -18,7 +18,9 @@ function TimesheetRow({ timesheet }: TimesheetRowProps): JSX.Element {
     const archiveTimesheet = async (timesheet: Timesheet, e: React.MouseEvent) => {
         e.preventDefault();
         try {
-            await putTimesheet({ ...timesheet, status: 'ARCHIVED' });
+            await putTimesheet({ ...timesheet, status: 'ARCHIVED' }, () => {
+                undefined;
+            });
         } catch (error) {
             setErrorMessage(`${error}`);
         }

--- a/lib/hooks/useCustomers.ts
+++ b/lib/hooks/useCustomers.ts
@@ -10,7 +10,7 @@ type CustomerList = {
 };
 
 type CustomersUpdate = {
-    postCustomer: (customer: Customer) => void;
+    postCustomer: (customer: Customer, errorHandler: (error: Error) => void) => Promise<Customer | undefined>;
 };
 
 export const useCustomers = (): CustomerList => {
@@ -20,10 +20,10 @@ export const useCustomers = (): CustomerList => {
 
 export const useUpdateCustomers = (): CustomersUpdate => {
     const { mutate } = useSWRConfig();
-    const postCustomer = async (customer: Customer) => {
-        const response = await post(customerEndpointURL, customer);
+    const postCustomer = async (customer: Customer, errorHandler: (error: Error) => void) => {
+        const newCustomer = await post<Customer, Customer>(customerEndpointURL, customer).catch(errorHandler);
         mutate(customerEndpointURL);
-        return response;
+        return newCustomer || undefined;
     };
     return { postCustomer };
 };

--- a/lib/hooks/useProjects.ts
+++ b/lib/hooks/useProjects.ts
@@ -18,8 +18,8 @@ interface ProjectDetail {
     projectDetailResponse: ApiResponseType<Project>;
 }
 interface UpdateProjects {
-    postProject: (project: Project) => void;
-    putProject: (project: Project) => void;
+    postProject: (project: Project, errorHandler: (error: Error) => void) => Promise<Project | undefined>;
+    putProject: (project: Project, errorHandler: (error: Error) => void) => Promise<Project | undefined>;
 }
 
 export const useProjects = (): ProjectList => {
@@ -38,18 +38,18 @@ export const useUpdateProjects = (): UpdateProjects => {
     const { mutate } = useSWRConfig();
     const matchMutate = useMatchMutate();
 
-    const postProject = async (project: Project) => {
-        const response = await post(projectEndpointURL, project);
+    const postProject = async (project: Project, errorHandler: (error: Error) => void) => {
+        const newProject = await post<Project, Project>(projectEndpointURL, project).catch(errorHandler);
         mutate(projectEndpointURL);
         matchMutate(projectIdEndpointCacheKeyRegex);
-        return response;
+        return newProject || undefined;
     };
 
-    const putProject = async (project: Project) => {
-        const response = await put(projectEndpointURL, project);
+    const putProject = async (project: Project, errorHandler: (error: Error) => void) => {
+        const updatedProject = await put<Project, Project>(projectEndpointURL, project).catch(errorHandler);
         mutate(projectEndpointURL);
         matchMutate(projectIdEndpointCacheKeyRegex);
-        return response;
+        return updatedProject || undefined;
     };
 
     return { postProject, putProject };

--- a/lib/hooks/useTasks.ts
+++ b/lib/hooks/useTasks.ts
@@ -10,8 +10,8 @@ type TaskList = {
 };
 
 type UpdateTasks = {
-    postTask: (task: Task) => void;
-    putTask: (task: Task) => void;
+    postTask: (task: Task, errorHandler: (error: Error) => void) => Promise<Task | undefined>;
+    putTask: (task: Task, errorHandler: (error: Error) => void) => Promise<Task | undefined>;
 };
 
 function useTasks(projectId: number): TaskList {
@@ -24,16 +24,16 @@ function useTasks(projectId: number): TaskList {
 export const useUpdateTasks = (): UpdateTasks => {
     const { mutate } = useSWRConfig();
 
-    const postTask = async (task: Task) => {
-        const response = await post(taskEndpointURL, task);
+    const postTask = async (task: Task, errorHandler: (error: Error) => void) => {
+        const newTask = await post<Task, Task>(taskEndpointURL, task).catch(errorHandler);
         mutate(taskEndpointURL);
-        return response;
+        return newTask || undefined;
     };
 
-    const putTask = async (task: Task) => {
-        const response = await put(taskEndpointURL, task);
+    const putTask = async (task: Task, errorHandler: (error: Error) => void) => {
+        const updatedTask = await put<Task, Task>(taskEndpointURL, task).catch(errorHandler);
         mutate(taskEndpointURL);
-        return response;
+        return updatedTask || undefined;
     };
     return { postTask, putTask };
 };

--- a/lib/hooks/useTimesheets.ts
+++ b/lib/hooks/useTimesheets.ts
@@ -10,8 +10,8 @@ type TimesheetList = {
 };
 
 type UpdateTimesheets = {
-    postTimesheet: (timesheet: Timesheet) => void;
-    putTimesheet: (timesheet: Timesheet) => void;
+    postTimesheet: (timesheet: Timesheet, errorHandler: (error: Error) => void) => Promise<Timesheet | undefined>;
+    putTimesheet: (timesheet: Timesheet, errorHandler: (error: Error) => void) => Promise<Timesheet | undefined>;
 };
 
 export const useTimesheets = (projectId: number): TimesheetList => {
@@ -24,15 +24,16 @@ export const useTimesheets = (projectId: number): TimesheetList => {
 export const useUpdateTimesheets = (): UpdateTimesheets => {
     const { mutate } = useSWRConfig();
 
-    const postTimesheet = async (timesheet: Timesheet) => {
-        const response = await post(timesheetEndpointURL, timesheet);
+    const postTimesheet = async (timesheet: Timesheet, errorHandler: (error: Error) => void) => {
+        const newTimesheet = await post<Timesheet, Timesheet>(timesheetEndpointURL, timesheet).catch(errorHandler);
         mutate(timesheetEndpointURL);
-        return response;
+        return newTimesheet || undefined;
     };
-    const putTimesheet = async (timesheet: Timesheet) => {
-        const response = await put(timesheetEndpointURL, timesheet);
+
+    const putTimesheet = async (timesheet: Timesheet, errorHandler: (error: Error) => void) => {
+        const newTimesheet = await put<Timesheet, Timesheet>(timesheetEndpointURL, timesheet).catch(errorHandler);
         mutate(timesheetEndpointURL);
-        return response;
+        return newTimesheet || undefined;
     };
 
     return { postTimesheet, putTimesheet };

--- a/lib/types/forms.ts
+++ b/lib/types/forms.ts
@@ -1,0 +1,4 @@
+export type FormBase = {
+    afterSubmit?: () => void;
+    onCancel?: () => void;
+};

--- a/lib/types/forms.ts
+++ b/lib/types/forms.ts
@@ -1,4 +1,4 @@
-export type FormBase = {
-    afterSubmit?: () => void;
+export type FormBase<T> = {
+    afterSubmit?: (returnValue: T | undefined) => void;
     onCancel?: () => void;
 };

--- a/pages/projects/[id]/edit.tsx
+++ b/pages/projects/[id]/edit.tsx
@@ -11,19 +11,22 @@ import { useEmployees } from '@/lib/hooks/useEmployees';
 import { useProjectDetail } from '@/lib/hooks/useProjects';
 
 type Props = {
-    id: number;
+    projectId: number;
 };
 
-function EditProjectPage({ id }: Props): JSX.Element {
+function EditProjectPage({ projectId }: Props): JSX.Element {
+    const router = useRouter();
     const { customersResponse } = useCustomers();
     const { employeesResponse } = useEmployees();
-    const { projectDetailResponse } = useProjectDetail(id);
+    const { projectDetailResponse } = useProjectDetail(projectId);
 
     const errorMessage =
         (customersResponse.isError && customersResponse.errorMessage) ||
         (employeesResponse.isError && employeesResponse.errorMessage) ||
         (projectDetailResponse.isError && projectDetailResponse.errorMessage) ||
         '';
+
+    const redirectToProjectDetail = () => router.push(`/projects/${projectId}`);
 
     return (
         <Layout>
@@ -45,6 +48,8 @@ function EditProjectPage({ id }: Props): JSX.Element {
                         employees={employeesResponse.data}
                         project={projectDetailResponse.data}
                         projectId={projectDetailResponse.data.id}
+                        afterSubmit={redirectToProjectDetail}
+                        onCancel={redirectToProjectDetail}
                     />
                 )}
         </Layout>
@@ -54,7 +59,7 @@ function EditProjectPage({ id }: Props): JSX.Element {
 const Edit: NextPage = () => {
     const router = useRouter();
     const id = router.query.id as string | undefined;
-    return id ? <EditProjectPage id={Number(id)} /> : null;
+    return id ? <EditProjectPage projectId={Number(id)} /> : null;
 };
 
 export default Edit;

--- a/pages/projects/[id]/index.tsx
+++ b/pages/projects/[id]/index.tsx
@@ -32,9 +32,9 @@ function ProjectDetailPage({ projectId }: Props): JSX.Element {
     const archiveProject = async (e: React.MouseEvent) => {
         e.preventDefault();
         if (projectDetailResponse.isSuccess) {
-            await putProject({ ...projectDetailResponse.data, status: 'ARCHIVED' }, () => {
-                undefined;
-            });
+            await putProject({ ...projectDetailResponse.data, status: 'ARCHIVED' }, (error) =>
+                setErrorMessage(`${error}`),
+            );
             onOpen();
         } else {
             setErrorMessage('Project failed to load.');

--- a/pages/projects/[id]/index.tsx
+++ b/pages/projects/[id]/index.tsx
@@ -32,12 +32,10 @@ function ProjectDetailPage({ projectId }: Props): JSX.Element {
     const archiveProject = async (e: React.MouseEvent) => {
         e.preventDefault();
         if (projectDetailResponse.isSuccess) {
-            try {
-                await putProject({ ...projectDetailResponse.data, status: 'ARCHIVED' });
-                onOpen();
-            } catch (error) {
-                setErrorMessage(`${error}`);
-            }
+            await putProject({ ...projectDetailResponse.data, status: 'ARCHIVED' }, () => {
+                undefined;
+            });
+            onOpen();
         } else {
             setErrorMessage('Project failed to load.');
         }

--- a/pages/projects/new.tsx
+++ b/pages/projects/new.tsx
@@ -7,8 +7,10 @@ import Loading from '@/components/common/Loading';
 import { useCustomers } from '@/lib/hooks/useCustomers';
 import { useEmployees } from '@/lib/hooks/useEmployees';
 import { CreateProjectForm } from '@/components/form/ProjectForm';
+import { useRouter } from 'next/router';
 
 const New: NextPage = () => {
+    const router = useRouter();
     const { customersResponse } = useCustomers();
     const { employeesResponse } = useEmployees();
 
@@ -16,6 +18,8 @@ const New: NextPage = () => {
         (customersResponse.isError && customersResponse.errorMessage) ||
         (employeesResponse.isError && employeesResponse.errorMessage) ||
         '';
+
+    const redirectToProjectList = () => router.push('/projects');
 
     return (
         <Layout>
@@ -27,7 +31,12 @@ const New: NextPage = () => {
                 <ErrorAlert title={errorMessage} message={errorMessage} />
             )}
             {customersResponse.isSuccess && employeesResponse.isSuccess && (
-                <CreateProjectForm customers={customersResponse.data} employees={employeesResponse.data} />
+                <CreateProjectForm
+                    customers={customersResponse.data}
+                    employees={employeesResponse.data}
+                    afterSubmit={redirectToProjectList}
+                    onCancel={redirectToProjectList}
+                />
             )}
         </Layout>
     );


### PR DESCRIPTION
## Parent-agnostic forms

Ideally it should be possible to render the forms `CreateClientForm`, `CreateTaskForm` and `CreateTimesheetForm` anywhere: They should have no idea whether the parent is a modal or something else. This promotes component reuse and makes these forms much more useful in the long term.

I suggest we introduce optional `afterSubmit` and `onCancel` functions to forms. They allow patterns like
```
<CreateTaskForm afterSubmit={ closeModal } onCancel={ closeModal } />
```
in the parent.

## Typed update hooks

The update hooks are now typed correctly: A post method for type `Project` will return a newly created `Project`-object that can then be used

## Updated form generics

In relation to the updated hooks, objects created by forms are now accessible from the outside:

```
<CreateProjectForm afterSubmit={(newlyCreatedProject) => someFunction(newlyCreatedProject)}} />
```
is now possible. For example, you can now redirect to the newly created Project-page.

## Form error-handling

Form validation errors and HTTP-errors are now displayed in the UI. Some of these were broken by #78 