### PR TITLE
refactor: generic hook types

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,6 +18,7 @@
 # misc
 .DS_Store
 *.pem
+tsconfig.tsbuildinfo
 
 # debug
 npm-debug.log*

--- a/components/table/TaskTable.tsx
+++ b/components/table/TaskTable.tsx
@@ -94,7 +94,7 @@ function TaskTable({ project, tasks }: TaskTableProps): JSX.Element {
                             <CreateTaskForm
                                 project={project}
                                 projectId={project.id}
-                                afterSubmit={(task) => (task ? setDisplayNewTaskForm(false) : undefined)}
+                                afterSubmit={(taskUpdate) => taskUpdate.isSuccess && setDisplayNewTaskForm(false)}
                                 onCancel={() => setDisplayNewTaskForm(false)}
                             />
                         </ModalContent>

--- a/components/table/TimesheetTable.tsx
+++ b/components/table/TimesheetTable.tsx
@@ -104,7 +104,9 @@ function TimesheetTable({ project, timesheets, employees }: TimesheetTableProps)
                             project={project}
                             projectId={project.id}
                             employees={employees}
-                            afterSubmit={(timesheet) => (timesheet ? setDisplayNewTimesheetForm(false) : undefined)}
+                            afterSubmit={(timesheetUpdate) =>
+                                timesheetUpdate.isSuccess && setDisplayNewTimesheetForm(false)
+                            }
                             onCancel={() => setDisplayNewTimesheetForm(false)}
                         />
                         <ModalCloseButton />

--- a/lib/hooks/useEmployees.ts
+++ b/lib/hooks/useEmployees.ts
@@ -1,15 +1,9 @@
 import useSWR from 'swr';
 import { Employee } from '../types/apiTypes';
 import { get } from '../utils/fetch';
-import { ApiResponseType, swrToData } from '../types/swrUtil';
+import { ApiGetResponse, swrToApiGetResponse } from '../types/hooks';
 
 const employeeEndpointURL = `${process.env.NEXT_PUBLIC_API_URL}/employee`;
 
-type EmployeeList = {
-    employeesResponse: ApiResponseType<Employee[]>;
-};
-
-export const useEmployees = (): EmployeeList => {
-    const employeesResponse = swrToData(useSWR<Employee[], Error>(employeeEndpointURL, get));
-    return { employeesResponse };
-};
+export const useEmployees = (): ApiGetResponse<Employee[]> =>
+    swrToApiGetResponse(useSWR<Employee[], Error>(employeeEndpointURL, get));

--- a/lib/hooks/useTasks.ts
+++ b/lib/hooks/useTasks.ts
@@ -1,40 +1,39 @@
 import useSWR, { useSWRConfig } from 'swr';
 import { Task } from '../types/apiTypes';
 import { get, post, put } from '../utils/fetch';
-import { swrToData, ApiResponseType } from '../types/swrUtil';
+import {
+    swrToApiGetResponse,
+    ApiGetResponse,
+    UpdateHookArgs,
+    UpdateHookFunction,
+    updateToApiUpdateResponse,
+} from '../types/hooks';
 
 const taskEndpointURL = `${process.env.NEXT_PUBLIC_API_URL}/task`;
 
-type TaskList = {
-    tasksResponse: ApiResponseType<Task[]>;
-};
-
 type UpdateTasks = {
-    postTask: (task: Task, errorHandler: (error: Error) => void) => Promise<Task | undefined>;
-    putTask: (task: Task, errorHandler: (error: Error) => void) => Promise<Task | undefined>;
+    postTask: UpdateHookFunction<Task>;
+    putTask: UpdateHookFunction<Task>;
 };
 
-function useTasks(projectId: number): TaskList {
-    const tasksResponse = swrToData(
-        useSWR<Task[], Error>(taskEndpointURL, () => get(taskEndpointURL, { projectId: projectId })),
-    );
-    return { tasksResponse };
-}
+const useTasks = (projectId: number): ApiGetResponse<Task[]> =>
+    swrToApiGetResponse(useSWR<Task[], Error>(taskEndpointURL, () => get(taskEndpointURL, { projectId: projectId })));
 
 export const useUpdateTasks = (): UpdateTasks => {
     const { mutate } = useSWRConfig();
 
-    const postTask = async (task: Task, errorHandler: (error: Error) => void) => {
+    const postTask = async (...[task, errorHandler]: UpdateHookArgs<Task>) => {
         const newTask = await post<Task, Task>(taskEndpointURL, task).catch(errorHandler);
         mutate(taskEndpointURL);
-        return newTask || undefined;
+        return updateToApiUpdateResponse(newTask || undefined);
     };
 
-    const putTask = async (task: Task, errorHandler: (error: Error) => void) => {
+    const putTask = async (...[task, errorHandler]: UpdateHookArgs<Task>) => {
         const updatedTask = await put<Task, Task>(taskEndpointURL, task).catch(errorHandler);
         mutate(taskEndpointURL);
-        return updatedTask || undefined;
+        return updateToApiUpdateResponse(updatedTask || undefined);
     };
+
     return { postTask, putTask };
 };
 

--- a/lib/hooks/useTimesheets.ts
+++ b/lib/hooks/useTimesheets.ts
@@ -1,39 +1,39 @@
 import useSWR, { useSWRConfig } from 'swr';
 import { Timesheet } from '../types/apiTypes';
+import {
+    ApiGetResponse,
+    swrToApiGetResponse,
+    UpdateHookArgs,
+    UpdateHookFunction,
+    updateToApiUpdateResponse,
+} from '../types/hooks';
 import { get, post, put } from '../utils/fetch';
-import { swrToData, ApiResponseType } from '../types/swrUtil';
 
 const timesheetEndpointURL = `${process.env.NEXT_PUBLIC_API_URL}/timesheet`;
 
-type TimesheetList = {
-    timesheetsResponse: ApiResponseType<Timesheet[]>;
-};
-
 type UpdateTimesheets = {
-    postTimesheet: (timesheet: Timesheet, errorHandler: (error: Error) => void) => Promise<Timesheet | undefined>;
-    putTimesheet: (timesheet: Timesheet, errorHandler: (error: Error) => void) => Promise<Timesheet | undefined>;
+    postTimesheet: UpdateHookFunction<Timesheet>;
+    putTimesheet: UpdateHookFunction<Timesheet>;
 };
 
-export const useTimesheets = (projectId: number): TimesheetList => {
-    const timesheetsResponse = swrToData(
+export const useTimesheets = (projectId: number): ApiGetResponse<Timesheet[]> =>
+    swrToApiGetResponse(
         useSWR<Timesheet[], Error>(timesheetEndpointURL, () => get(timesheetEndpointURL, { projectId: projectId })),
     );
-    return { timesheetsResponse };
-};
 
 export const useUpdateTimesheets = (): UpdateTimesheets => {
     const { mutate } = useSWRConfig();
 
-    const postTimesheet = async (timesheet: Timesheet, errorHandler: (error: Error) => void) => {
+    const postTimesheet = async (...[timesheet, errorHandler]: UpdateHookArgs<Timesheet>) => {
         const newTimesheet = await post<Timesheet, Timesheet>(timesheetEndpointURL, timesheet).catch(errorHandler);
         mutate(timesheetEndpointURL);
-        return newTimesheet || undefined;
+        return updateToApiUpdateResponse(newTimesheet || undefined);
     };
 
-    const putTimesheet = async (timesheet: Timesheet, errorHandler: (error: Error) => void) => {
-        const newTimesheet = await put<Timesheet, Timesheet>(timesheetEndpointURL, timesheet).catch(errorHandler);
+    const putTimesheet = async (...[timesheet, errorHandler]: UpdateHookArgs<Timesheet>) => {
+        const updatedTimesheet = await put<Timesheet, Timesheet>(timesheetEndpointURL, timesheet).catch(errorHandler);
         mutate(timesheetEndpointURL);
-        return newTimesheet || undefined;
+        return updateToApiUpdateResponse(updatedTimesheet || undefined);
     };
 
     return { postTimesheet, putTimesheet };

--- a/lib/types/forms.ts
+++ b/lib/types/forms.ts
@@ -1,4 +1,6 @@
+import { ApiUpdateResponse } from './hooks';
+
 export type FormBase<T> = {
-    afterSubmit?: (returnValue: T | undefined) => void;
+    afterSubmit?: (returnValue: ApiUpdateResponse<T>) => void;
     onCancel?: () => void;
 };

--- a/lib/types/hooks.ts
+++ b/lib/types/hooks.ts
@@ -1,4 +1,4 @@
-export type ApiResponseType<T> =
+export type ApiGetResponse<T> =
     | {
           isSuccess: true;
           isLoading: false;
@@ -17,9 +17,23 @@ export type ApiResponseType<T> =
           isError: false;
       };
 
+export type ApiUpdateResponse<T> =
+    | {
+          isSuccess: true;
+          isError: false;
+          data: T;
+      }
+    | {
+          isSuccess: false;
+          isError: true;
+      };
+
+export type UpdateHookArgs<T> = [updatedObject: T, errorHandler: (error: Error) => void];
+export type UpdateHookFunction<T> = (...args: UpdateHookArgs<T>) => Promise<ApiUpdateResponse<T>>;
+
 export type swrType<T> = { data?: T; error?: { message: string } };
 
-export const swrToData = <T>({ data, error }: swrType<T>): ApiResponseType<T> => {
+export const swrToApiGetResponse = <T>({ data, error }: swrType<T>): ApiGetResponse<T> => {
     if (error) {
         return { isSuccess: false, isLoading: false, isError: true, errorMessage: error.message };
     } else if (!data) {
@@ -28,3 +42,6 @@ export const swrToData = <T>({ data, error }: swrType<T>): ApiResponseType<T> =>
         return { isSuccess: true, isLoading: false, isError: false, data: data };
     }
 };
+
+export const updateToApiUpdateResponse = <T>(response?: T): ApiUpdateResponse<T> =>
+    response ? { isSuccess: true, isError: false, data: response } : { isSuccess: false, isError: true };

--- a/pages/projects/[id]/edit.tsx
+++ b/pages/projects/[id]/edit.tsx
@@ -16,9 +16,10 @@ type Props = {
 
 function EditProjectPage({ projectId }: Props): JSX.Element {
     const router = useRouter();
-    const { customersResponse } = useCustomers();
-    const { employeesResponse } = useEmployees();
-    const { projectDetailResponse } = useProjectDetail(projectId);
+
+    const customersResponse = useCustomers();
+    const employeesResponse = useEmployees();
+    const projectDetailResponse = useProjectDetail(projectId);
 
     const errorMessage =
         (customersResponse.isError && customersResponse.errorMessage) ||

--- a/pages/projects/[id]/index.tsx
+++ b/pages/projects/[id]/index.tsx
@@ -5,7 +5,7 @@ import { useRouter } from 'next/dist/client/router';
 import ErrorAlert from '@/components/common/ErrorAlert';
 import Loading from '@/components/common/Loading';
 import Layout from '@/components/common/Layout';
-import { Button, Modal, ModalBody, ModalContent, ModalFooter, ModalOverlay, useDisclosure } from '@chakra-ui/react';
+import { Button, Modal, ModalBody, ModalContent, ModalFooter, ModalOverlay } from '@chakra-ui/react';
 import Link from 'next/link';
 import TimesheetTable from '@/components/table/TimesheetTable';
 import TaskTable from '@/components/table/TaskTable';
@@ -20,13 +20,14 @@ type Props = {
 };
 
 function ProjectDetailPage({ projectId }: Props): JSX.Element {
-    const { projectDetailResponse } = useProjectDetail(projectId);
-    const { putProject } = useUpdateProjects();
-    const { timesheetsResponse } = useTimesheets(projectId);
-    const { employeesResponse } = useEmployees();
-    const { tasksResponse } = useTasks(projectId);
+    const projectDetailResponse = useProjectDetail(projectId);
+    const timesheetsResponse = useTimesheets(projectId);
+    const employeesResponse = useEmployees();
+    const tasksResponse = useTasks(projectId);
 
-    const { isOpen, onOpen, onClose } = useDisclosure();
+    const { putProject } = useUpdateProjects();
+
+    const [displayArchivedModal, setDisplayArchivedModal] = useState(false);
     const [errorMessage, setErrorMessage] = useState<string>('');
 
     const archiveProject = async (e: React.MouseEvent) => {
@@ -35,7 +36,7 @@ function ProjectDetailPage({ projectId }: Props): JSX.Element {
             await putProject({ ...projectDetailResponse.data, status: 'ARCHIVED' }, (error) =>
                 setErrorMessage(`${error}`),
             );
-            onOpen();
+            setDisplayArchivedModal(true);
         } else {
             setErrorMessage('Project failed to load.');
         }
@@ -68,13 +69,13 @@ function ProjectDetailPage({ projectId }: Props): JSX.Element {
                             Archive Project
                         </Button>
                     )}
-                    <Modal isOpen={isOpen} onClose={onClose}>
+                    <Modal isOpen={displayArchivedModal} onClose={() => setDisplayArchivedModal(false)}>
                         <ModalOverlay />
                         <ModalContent>
                             <ModalBody marginTop="1rem">{projectDetailResponse.data.name} has been archived.</ModalBody>
 
                             <ModalFooter>
-                                <Button colorScheme="blue" onClick={onClose}>
+                                <Button colorScheme="blue" onClick={() => setDisplayArchivedModal(false)}>
                                     Close
                                 </Button>
                             </ModalFooter>

--- a/pages/projects/index.tsx
+++ b/pages/projects/index.tsx
@@ -11,7 +11,7 @@ import { useProjects } from '@/lib/hooks/useProjects';
 
 const Projects: NextPage = () => {
     const router = useRouter();
-    const { projectsResponse } = useProjects();
+    const projectsResponse = useProjects();
 
     return (
         <Layout>

--- a/pages/projects/new.tsx
+++ b/pages/projects/new.tsx
@@ -11,8 +11,8 @@ import { useRouter } from 'next/router';
 
 const New: NextPage = () => {
     const router = useRouter();
-    const { customersResponse } = useCustomers();
-    const { employeesResponse } = useEmployees();
+    const customersResponse = useCustomers();
+    const employeesResponse = useEmployees();
 
     const errorMessage =
         (customersResponse.isError && customersResponse.errorMessage) ||


### PR DESCRIPTION
## Generic hook types

Refactor hook types to the most natural ones and leverage generics in making the files much prettier. For update functions we define
```
export type UpdateHookArgs<T> = [updatedObject: T, errorHandler: (error: Error) => void];
export type UpdateHookFunction<T> = (...args: UpdateHookArgs<T>) => Promise<ApiUpdateResponse<T>>;
```
That allows us to rewrite the following definition from the `main` branch
```
interface UpdateProjects {
    postProject: (project: Project, errorHandler: (error: Error) => void) => Promise<Project | undefined>;
    putProject: (project: Project, errorHandler: (error: Error) => void) => Promise<Project | undefined>;
}
```
as
```
interface UpdateProjects {
    postProject: UpdateHookFunction<Project>;
    putProject: UpdateHookFunction<Project>;
}
```
Also, the function signatures go from
```
const postProject = async (project: Project, errorHandler: (error: Error) => void) => { ... }
```
to
```
const postProject = async (...[project, errorHandler]: UpdateHookArgs<Project>) => { ... }
```
As a result, the hooks become much more legible.

## Update request type

Currently `GET` requests return objects that have `isSuccess`, `isError` and `isLoading` fields. Make update requests return objects that have `isSuccess` and `isError` fields (no `isLoading` is provided due to how the hooks work,  it's still possible to easily implement this in the component that uses update hooks if needed).

The type is
```
export type ApiUpdateResponse<T> =
    | {
          isSuccess: true;
          isError: false;
          data: T;
      }
    | {
          isSuccess: false;
          isError: true;
      };
```
i.e. `data` of type `T` is defined if and only if `isSuccess` is true.
 
Example: After these changes, the correct way to hide task form modal after a new task is successfully created, becomes
```
<CreateTaskForm
    project={project}
    projectId={project.id}
    afterSubmit={(taskUpdate) => taskUpdate.isSuccess && setDisplayNewTaskForm(false)}
    onCancel={() => setDisplayNewTaskForm(false)}
/>
```
I think this significantly promotes idiomatic code.