### PR TITLE
fix: fix task post validation

### DIFF
--- a/lib/hooks/useTasks.ts
+++ b/lib/hooks/useTasks.ts
@@ -12,8 +12,6 @@ import { NEXT_PUBLIC_API_URL } from "../conf"
 import { User } from "firebase/auth"
 
 const taskEndpointURL = `${NEXT_PUBLIC_API_URL}/task`
-const taskByProjectEndpointURL = (projectId: number) =>
-    `${NEXT_PUBLIC_API_URL}/task?projectId=${projectId}`
 
 type UpdateTasks = {
     postTask: UpdateHookFunction<Task>
@@ -22,7 +20,7 @@ type UpdateTasks = {
 
 const useTasks = (projectId: number, user: User): ApiGetResponse<Task[]> =>
     swrToApiGetResponse(
-        useSWR<Task[], Error>(taskByProjectEndpointURL(projectId), () =>
+        useSWR<Task[], Error>(taskEndpointURL, () =>
             get(taskEndpointURL, user, { projectId })
         )
     )


### PR DESCRIPTION
As of `main`, there is a mismatch between SWR cache keys [here](https://github.com/three-consulting/epoc-frontend/blob/main/lib/hooks/useTasks.ts#L25-L26) and the corresponding mutate's [here](https://github.com/three-consulting/epoc-frontend/blob/main/lib/hooks/useTasks.ts#L39) and [here](https://github.com/three-consulting/epoc-frontend/blob/main/lib/hooks/useTasks.ts#L50). This breaks task post validation as pointed out by @robertsiipola.

It's probably easiest to just drop `taskByProjectEndpointURL` and use `taskEndpointURL` as a cache key throughout to amend this.