### PR TITLE
fix: uncontrolled input to controlled

### DIFF
--- a/components/form/CustomerForm.tsx
+++ b/components/form/CustomerForm.tsx
@@ -73,7 +73,7 @@ function CustomerForm({
                         <FormLabel>Customer Name</FormLabel>
                         <Input
                             placeholder="Customer Name"
-                            value={customerFields.name}
+                            value={customerFields.name || ""}
                             onChange={(event) =>
                                 setCustomerFields({
                                     ...customerFields,
@@ -88,7 +88,7 @@ function CustomerForm({
                         <FormLabel>Description</FormLabel>
                         <Input
                             placeholder="Description"
-                            value={customerFields.description}
+                            value={customerFields.description || ""}
                             onChange={(event) =>
                                 setCustomerFields({
                                     ...customerFields,


### PR DESCRIPTION
Currently, the `CustomerForm` component input values may not be set when the form is first rendered. This produces an annoying warning in `yarn test` and is against React principles. Here's a small change to fix that.