### PR TITLE
fix: post validation endpoint regex

### DIFF
--- a/lib/hooks/swrInterface.ts
+++ b/lib/hooks/swrInterface.ts
@@ -21,7 +21,7 @@ export type Endpoint =
     | `time-category`
 
 export const endpointRegex = (endpoint: Endpoint): RegExp =>
-    new RegExp(`^/${endpoint}[/|?].+`)
+    new RegExp(`^/${endpoint}([/|?].+)?`)
 
 const prefixEndpoint = (endpoint: Endpoint) =>
     `${NEXT_PUBLIC_API_URL}/${endpoint}`


### PR DESCRIPTION
The regex `^/${endpoint}[/|?].+` does match, `/customer/2`, `/customer?asd=asd` etc. but it does not match `/customer` (without the backslash at the end). This breaks the post validation when a new customer is created because the customer list is fetched from `/customer`.

I think the suffix `[/|?].+` should be optional, so the correct regex should be `^/${endpoint}([/|?].+)?`.