### PR TITLE
fix: homepage table headers responsive

### DIFF
--- a/components/common/Buttons.tsx
+++ b/components/common/Buttons.tsx
@@ -10,7 +10,7 @@ import {
 } from "@chakra-ui/react"
 import React from "react"
 import { IconType } from "react-icons"
-import { BsX } from "react-icons/bs"
+import { BsSortNumericDown, BsSortNumericDownAlt, BsX } from "react-icons/bs"
 
 const capitalize = (input: string): string =>
     input.charAt(0).toUpperCase() + input.slice(1)
@@ -116,6 +116,22 @@ export const RemoveIconButton = (props: IconButtonProps): JSX.Element => (
     <StyledIconButton
         {...props}
         iconType={BsX}
+        color="whitesmoke"
+        backgroundColor="#6f6f6f"
+        hover={true}
+    />
+)
+
+interface ISortingOrderIconButton extends IconButtonProps {
+    oldestFirst: boolean
+}
+
+export const SortingOrderIconButton = (
+    props: ISortingOrderIconButton
+): JSX.Element => (
+    <StyledIconButton
+        {...props}
+        iconType={props.oldestFirst ? BsSortNumericDown : BsSortNumericDownAlt}
         color="whitesmoke"
         backgroundColor="#6f6f6f"
         hover={true}

--- a/components/common/Header.tsx
+++ b/components/common/Header.tsx
@@ -34,6 +34,7 @@ const components: Record<string, StyleConfig> = {
             tableHeader: {
                 bg: "#6f6f6f",
                 paddingX: "1.5rem",
+                _hover: { cursor: "pointer" },
             },
         },
         defaultProps: {
@@ -90,16 +91,18 @@ const Header = ({ children, type }: IHeader) => {
 
 export const TableHeader = ({
     text,
-    button,
+    icon,
+    onClick,
 }: {
     text: string
-    button?: JSX.Element
+    icon?: JSX.Element
+    onClick?: () => void
 }) => (
     <StyledItems>
-        <Heading as="h4" variant="tableHeader" size="sm">
+        <Heading as="h4" variant="tableHeader" size="sm" onClick={onClick}>
             <Flex justifyContent="space-between" alignItems="center">
                 <Box>{text}</Box>
-                <Box>{button}</Box>
+                <Box>{icon}</Box>
             </Flex>
         </Heading>
     </StyledItems>


### PR DESCRIPTION
- Home page table headers are responsive
- Previous entries section is visible only when some dates have been selected
- Added a sorting button for previous entries  