### PR TITLE
drop user context

### DIFF
--- a/components/common/LeftNav.tsx
+++ b/components/common/LeftNav.tsx
@@ -1,4 +1,4 @@
-import React, { useContext } from "react"
+import React from "react"
 import {
     Text,
     Flex,
@@ -21,8 +21,7 @@ import {
     BsFillFileTextFill,
 } from "react-icons/bs"
 import { IconType } from "react-icons"
-import { Role } from "@/lib/types/auth"
-import { AuthContext } from "@/lib/contexts/FirebaseAuthContext"
+import { FirebaseAuthStateNullableUser, Role } from "@/lib/types/auth"
 import Link from "next/link"
 
 interface LinkItemProps {
@@ -88,10 +87,12 @@ const NavItem = ({ name, icon, href }: LinkItemProps) => (
     </Link>
 )
 
-function LeftNav(): JSX.Element {
-    const { user, role, signInWithGoogle, signOutAndClear } =
-        useContext(AuthContext)
-
+function LeftNav({
+    user,
+    role,
+    signInWithGoogle,
+    signOutAndClear,
+}: FirebaseAuthStateNullableUser): JSX.Element {
     const isAdmin = role === Role.ADMIN
     const isLoggedIn = user !== null
 

--- a/components/common/Main.tsx
+++ b/components/common/Main.tsx
@@ -1,10 +1,11 @@
 import React, { ReactNode, useContext } from "react"
 import { Box, Flex } from "@chakra-ui/react"
 import LeftNav from "./LeftNav"
-import { AuthContext } from "@/lib/contexts/FirebaseAuthContext"
 import FormPage from "./FormPage"
 import Header from "./Header"
 import { MediaContext } from "@/lib/contexts/MediaContext"
+import useFirebaseAuth from "@/lib/hooks/useFirebaseAuth"
+import { AuthProvider } from "@/lib/contexts/FirebaseAuthContext"
 
 interface MainProps {
     children?: ReactNode
@@ -19,8 +20,8 @@ const PleaseLogInPage = ({ isLarge }: { isLarge: boolean }) => (
 )
 
 const Main = ({ children }: MainProps): JSX.Element => {
-    const { user } = useContext(AuthContext)
-
+    const auth = useFirebaseAuth()
+    const { user } = auth
     const { isLarge } = useContext(MediaContext)
     return (
         <Flex
@@ -29,8 +30,16 @@ const Main = ({ children }: MainProps): JSX.Element => {
             justifyContent="center"
             minHeight="100vh"
         >
-            {isLarge && <LeftNav />}
-            <Box>{user ? children : <PleaseLogInPage isLarge={isLarge} />}</Box>
+            {isLarge && <LeftNav {...auth} />}
+            <Box>
+                {user && user.email ? (
+                    <AuthProvider auth={{ ...auth, user, email: user.email }}>
+                        {children}
+                    </AuthProvider>
+                ) : (
+                    <PleaseLogInPage isLarge={isLarge} />
+                )}
+            </Box>
         </Flex>
     )
 }

--- a/components/editor/TimesheetEntryEditor/DayEditor.tsx
+++ b/components/editor/TimesheetEntryEditor/DayEditor.tsx
@@ -2,7 +2,7 @@ import { SortingOrderIconButton } from "@/components/common/Buttons"
 import Header from "@/components/common/Header"
 import { CreateTimesheetEntryForm } from "@/components/form/TimesheetEntryForm"
 import ImportFromCSVModal from "@/components/modal/ImportFromCSVModal"
-import { UserContext } from "@/lib/contexts/FirebaseAuthContext"
+import { AuthContext } from "@/lib/contexts/FirebaseAuthContext"
 import { MediaContext } from "@/lib/contexts/MediaContext"
 import { useUpdateTimesheetEntries } from "@/lib/hooks/useUpdate"
 import { Task, Timesheet, TimesheetEntry } from "@/lib/types/apiTypes"
@@ -57,7 +57,7 @@ const DayEditor = ({
 }: IDayEditor): JSX.Element => {
     const { isLarge } = useContext(MediaContext)
 
-    const { user } = useContext(UserContext)
+    const { user } = useContext(AuthContext)
     const { delete: del } = useUpdateTimesheetEntries(user)
 
     const [timesheet, setTimesheet] = useState<Timesheet | undefined>(undefined)

--- a/components/form/CustomerForm.tsx
+++ b/components/form/CustomerForm.tsx
@@ -4,11 +4,11 @@ import { Customer } from "@/lib/types/apiTypes"
 import { useUpdateCustomers } from "@/lib/hooks/useUpdate"
 import { FormBase } from "@/lib/types/forms"
 import ErrorAlert from "../common/ErrorAlert"
-import { UserContext } from "@/lib/contexts/FirebaseAuthContext"
 import { customerFieldMetadata } from "@/lib/types/typeMetadata"
 import FormSection from "../common/FormSection"
 import StyledButtons from "../common/StyledButtons"
 import { StyledButton } from "../common/Buttons"
+import { AuthContext } from "@/lib/contexts/FirebaseAuthContext"
 
 type CustomerFormPropsBase = FormBase<Customer>
 type CustomerFields = Partial<Customer>
@@ -110,7 +110,7 @@ function CustomerForm({
 export const CreateCustomerForm = (
     props: CreateCustomerFormProps
 ): JSX.Element => {
-    const { user } = useContext(UserContext)
+    const { user } = useContext(AuthContext)
     const { post } = useUpdateCustomers(user)
 
     const { customer } = props
@@ -152,7 +152,7 @@ export const CreateCustomerForm = (
 }
 
 export const EditCustomerForm = (props: EditCustomerFormProps): JSX.Element => {
-    const { user } = useContext(UserContext)
+    const { user } = useContext(AuthContext)
     const { put } = useUpdateCustomers(user)
 
     const { customer } = props
@@ -190,7 +190,7 @@ export const EditCustomerForm = (props: EditCustomerFormProps): JSX.Element => {
 export const AddCustomerForm = (
     props: CreateCustomerFormProps
 ): JSX.Element => {
-    const { user } = useContext(UserContext)
+    const { user } = useContext(AuthContext)
     const { post } = useUpdateCustomers(user)
 
     const { customer } = props

--- a/components/form/EmployeeForm.tsx
+++ b/components/form/EmployeeForm.tsx
@@ -4,13 +4,13 @@ import { Employee } from "@/lib/types/apiTypes"
 import { useUpdateEmployees } from "@/lib/hooks/useUpdate"
 import { FormBase } from "@/lib/types/forms"
 import ErrorAlert from "../common/ErrorAlert"
-import { UserContext } from "@/lib/contexts/FirebaseAuthContext"
 import { employeeFieldMetadata } from "@/lib/types/typeMetadata"
 import WarningModal from "../common/WarningModal"
 import StyledButtons from "../common/StyledButtons"
 import { StyledButton } from "../common/Buttons"
 import { isError } from "lodash"
 import FormSection from "../common/FormSection"
+import { AuthContext } from "@/lib/contexts/FirebaseAuthContext"
 
 type CreateEmployeeFormProps = FormBase<Employee>
 
@@ -243,7 +243,7 @@ const EmployeeForm = ({ onSubmit, onCancel, employee }: EmployeeFormProps) => {
 }
 
 export const EditEmployeeForm = (props: EditEmployeeFormProps): JSX.Element => {
-    const { user } = useContext(UserContext)
+    const { user } = useContext(AuthContext)
     const { put } = useUpdateEmployees(user)
 
     const { employee } = props

--- a/components/form/ProjectForm.tsx
+++ b/components/form/ProjectForm.tsx
@@ -1,4 +1,3 @@
-import { UserContext } from "@/lib/contexts/FirebaseAuthContext"
 import { useUpdateProjects } from "@/lib/hooks/useUpdate"
 import { Customer, Employee, Project } from "@/lib/types/apiTypes"
 import { FormBase } from "@/lib/types/forms"
@@ -18,6 +17,7 @@ import FormSection from "../common/FormSection"
 import { NewCustomerModal } from "../common/FormFields"
 import StyledButtons from "../common/StyledButtons"
 import { StyledButton } from "../common/Buttons"
+import { AuthContext } from "@/lib/contexts/FirebaseAuthContext"
 
 type CreateProjectFormProps = FormBase<Project> & {
     employees: Employee[]
@@ -279,7 +279,7 @@ function ProjectForm({
 export const CreateProjectForm = (
     props: CreateProjectFormProps
 ): JSX.Element => {
-    const { user } = useContext(UserContext)
+    const { user } = useContext(AuthContext)
     const { post } = useUpdateProjects(user)
 
     const [errorMessage, setErrorMessage] = useState<string>("")
@@ -304,7 +304,7 @@ export const CreateProjectForm = (
 }
 
 export const EditProjectForm = (props: EditProjectFormProps): JSX.Element => {
-    const { user } = useContext(UserContext)
+    const { user } = useContext(AuthContext)
     const { put } = useUpdateProjects(user)
 
     const [errorMessage, setErrorMessage] = useState<string>("")

--- a/components/form/TaskForm.tsx
+++ b/components/form/TaskForm.tsx
@@ -1,4 +1,3 @@
-import { UserContext } from "@/lib/contexts/FirebaseAuthContext"
 import { useUpdateTasks } from "@/lib/hooks/useUpdate"
 import { Project, Task } from "@/lib/types/apiTypes"
 import { FormBase } from "@/lib/types/forms"
@@ -9,6 +8,7 @@ import { CheckBoxField, FormContainer } from "../common/FormFields"
 import { taskFieldMetadata } from "@/lib/types/typeMetadata"
 import StyledButtons from "../common/StyledButtons"
 import { StyledButton } from "../common/Buttons"
+import { AuthContext } from "@/lib/contexts/FirebaseAuthContext"
 
 type CreateTaskFormProps = FormBase<Task> & {
     project: Project
@@ -137,7 +137,7 @@ function TaskForm({
 }
 
 export const CreateTaskForm = (props: CreateTaskFormProps): JSX.Element => {
-    const { user } = useContext(UserContext)
+    const { user } = useContext(AuthContext)
     const { post } = useUpdateTasks(user)
 
     const [errorMessage, setErrorMessage] = useState<string>("")
@@ -162,7 +162,7 @@ export const CreateTaskForm = (props: CreateTaskFormProps): JSX.Element => {
 }
 
 export const EditTaskForm = (props: EditTaskFormProps): JSX.Element => {
-    const { user } = useContext(UserContext)
+    const { user } = useContext(AuthContext)
     const { put } = useUpdateTasks(user)
 
     const [errorMessage, setErrorMessage] = useState<string>("")

--- a/components/form/TimesheetEntryForm.tsx
+++ b/components/form/TimesheetEntryForm.tsx
@@ -19,12 +19,12 @@ import ErrorAlert from "../common/ErrorAlert"
 import { FormButtons } from "../common/FormFields"
 import { timesheetEntryFieldMetadata } from "@/lib/types/typeMetadata"
 import { datesRange, jsDateToShortISODate } from "@/lib/utils/date"
-import { UserContext } from "@/lib/contexts/FirebaseAuthContext"
 import {
     useUpdateTimesheetEntries,
     useUpdateTimesheetEntry,
 } from "@/lib/hooks/useUpdate"
 import { isError } from "lodash"
+import { AuthContext } from "@/lib/contexts/FirebaseAuthContext"
 
 type TSetState<T> = Dispatch<SetStateAction<T>>
 type TimesheetEntryFields = Partial<TimesheetEntry>
@@ -232,7 +232,7 @@ export const EditTimesheetEntryForm = ({
     afterSubmit,
     ...props
 }: EditTimesheetEntryFormProps): JSX.Element => {
-    const { user } = useContext(UserContext)
+    const { user } = useContext(AuthContext)
     const { put } = useUpdateTimesheetEntry(user)
 
     const [errorMessage, setErrorMessage] = useState<string>("")
@@ -293,7 +293,7 @@ export const CreateTimesheetEntryForm = ({
     afterSubmit,
     ...props
 }: CreateTimesheetEntryFormProps): JSX.Element => {
-    const { user } = useContext(UserContext)
+    const { user } = useContext(AuthContext)
     const { post } = useUpdateTimesheetEntries(user)
 
     const [errorMessage, setErrorMessage] = useState<string>("")

--- a/components/form/TimesheetForm.tsx
+++ b/components/form/TimesheetForm.tsx
@@ -1,4 +1,3 @@
-import { UserContext } from "@/lib/contexts/FirebaseAuthContext"
 import { useUpdateTimesheets } from "@/lib/hooks/useUpdate"
 import { Employee, Project, Timesheet } from "@/lib/types/apiTypes"
 import { FormBase } from "@/lib/types/forms"
@@ -16,6 +15,7 @@ import ErrorAlert from "../common/ErrorAlert"
 import { timesheetFieldMetadata } from "@/lib/types/typeMetadata"
 import StyledButtons from "../common/StyledButtons"
 import { StyledButton } from "../common/Buttons"
+import { AuthContext } from "@/lib/contexts/FirebaseAuthContext"
 
 type CreateTimesheetFormProps = FormBase<Timesheet> & {
     employees: Employee[]
@@ -269,7 +269,7 @@ function TimesheetForm({
 export const CreateTimesheetForm = (
     props: CreateTimesheetFormProps
 ): JSX.Element => {
-    const { user } = useContext(UserContext)
+    const { user } = useContext(AuthContext)
     const { post } = useUpdateTimesheets(user)
 
     const [errorMessage, setErrorMessage] = useState<string>("")
@@ -296,7 +296,7 @@ export const CreateTimesheetForm = (
 export const EditTimesheetForm = (
     props: EditTimesheetFormProps
 ): JSX.Element => {
-    const { user } = useContext(UserContext)
+    const { user } = useContext(AuthContext)
     const { put } = useUpdateTimesheets(user)
 
     const [errorMessage, setErrorMessage] = useState<string>("")

--- a/components/modal/ImportFromCSVModal.tsx
+++ b/components/modal/ImportFromCSVModal.tsx
@@ -26,7 +26,6 @@ import {
 import { validateTimesheetEntryFields } from "../form/TimesheetEntryForm"
 import ErrorAlert from "../common/ErrorAlert"
 import { Task, Timesheet, TimesheetEntry } from "@/lib/types/apiTypes"
-import { UserContext } from "@/lib/contexts/FirebaseAuthContext"
 import { useUpdateTimesheetEntries } from "@/lib/hooks/useUpdate"
 import { useTasks, useTimesheets } from "@/lib/hooks/useList"
 import FromCsvTable from "../table/FromCsvTable"
@@ -35,6 +34,7 @@ import FileDropper from "../common/FileDropper"
 import FromCsvForm from "../form/FromCsvForm"
 import { CustomButton, StyledButton } from "../common/Buttons"
 import StyledButtons from "../common/StyledButtons"
+import { AuthContext } from "@/lib/contexts/FirebaseAuthContext"
 
 export type Timesheets = Array<Timesheet>
 export type Tasks = Array<Task>
@@ -51,7 +51,7 @@ interface IImportCsvDialog {
 const ImportFromCSVModal = ({
     setTimesheetEntries,
 }: IImportCsvDialog): JSX.Element => {
-    const { user } = useContext(UserContext)
+    const { user } = useContext(AuthContext)
     const { post } = useUpdateTimesheetEntries(user)
 
     const timesheets = useTimesheets(user)

--- a/components/table/TaskTable.tsx
+++ b/components/table/TaskTable.tsx
@@ -1,4 +1,3 @@
-import { UserContext } from "@/lib/contexts/FirebaseAuthContext"
 import { useUpdateTasks } from "@/lib/hooks/useUpdate"
 import { Project, Task } from "@/lib/types/apiTypes"
 import { Box } from "@chakra-ui/layout"
@@ -17,6 +16,7 @@ import ErrorAlert from "../common/ErrorAlert"
 import StyledButtons from "../common/StyledButtons"
 import FormSection from "../common/FormSection"
 import { CreateTaskForm, EditTaskForm } from "../form/TaskForm"
+import { AuthContext } from "@/lib/contexts/FirebaseAuthContext"
 
 interface TaskRowProps {
     task: Task
@@ -24,7 +24,7 @@ interface TaskRowProps {
 }
 
 function TaskRow({ task, onClick }: TaskRowProps): JSX.Element {
-    const { user } = useContext(UserContext)
+    const { user } = useContext(AuthContext)
     const { put } = useUpdateTasks(user)
 
     const [errorMessage, setErrorMessage] = useState<string>()

--- a/components/table/TimesheetTable.tsx
+++ b/components/table/TimesheetTable.tsx
@@ -12,18 +12,18 @@ import ErrorAlert from "../common/ErrorAlert"
 import { Employee, Project, Timesheet } from "@/lib/types/apiTypes"
 import { CreateTimesheetForm } from "../form/TimesheetForm"
 import { useRouter } from "next/router"
-import { UserContext } from "@/lib/contexts/FirebaseAuthContext"
 import { useUpdateTimesheets } from "@/lib/hooks/useUpdate"
 import FormSection from "../common/FormSection"
 import StyledButtons from "../common/StyledButtons"
 import { RemoveIconButton, StyledButton } from "../common/Buttons"
+import { AuthContext } from "@/lib/contexts/FirebaseAuthContext"
 
 interface TimesheetRowProps {
     timesheet: Timesheet
 }
 function TimesheetRow({ timesheet }: TimesheetRowProps): JSX.Element {
     const router = useRouter()
-    const { user } = useContext(UserContext)
+    const { user } = useContext(AuthContext)
     const { put } = useUpdateTimesheets(user)
 
     const [errorMessage, setErrorMessage] = useState<string>()

--- a/lib/contexts/FirebaseAuthContext.tsx
+++ b/lib/contexts/FirebaseAuthContext.tsx
@@ -1,31 +1,15 @@
 import React, { createContext, ReactNode } from "react"
-import { FirebaseAuthState, UserState } from "@/lib/types/auth"
-import useFirebaseAuth from "@/lib/hooks/useFirebaseAuth"
+import { FirebaseAuthState } from "@/lib/types/auth"
 
 export const AuthContext = createContext<FirebaseAuthState>(
     {} as FirebaseAuthState
 )
 
-export const UserContext = createContext<UserState>({} as UserState)
-
 interface AuthProps {
     children: ReactNode
+    auth: FirebaseAuthState
 }
 
-export const AuthProvider = ({ children }: AuthProps): JSX.Element => {
-    const auth = useFirebaseAuth()
-
-    return <AuthContext.Provider value={auth}>{children}</AuthContext.Provider>
-}
-
-export const UserProvider = ({ children }: AuthProps): JSX.Element | null => {
-    const { user } = useFirebaseAuth()
-
-    return (
-        user && (
-            <UserContext.Provider value={{ user }}>
-                {children}
-            </UserContext.Provider>
-        )
-    )
-}
+export const AuthProvider = ({ children, auth }: AuthProps): JSX.Element => (
+    <AuthContext.Provider value={auth}>{children}</AuthContext.Provider>
+)

--- a/lib/hooks/useFirebaseAuth.ts
+++ b/lib/hooks/useFirebaseAuth.ts
@@ -8,9 +8,9 @@ import {
     signInWithRedirect,
     GoogleAuthProvider,
 } from "firebase/auth"
-import { FirebaseAuthState, Role } from "@/lib/types/auth"
+import { FirebaseAuthStateNullableUser, Role } from "@/lib/types/auth"
 
-export default function useFirebaseAuth(): FirebaseAuthState {
+export default function useFirebaseAuth(): FirebaseAuthStateNullableUser {
     const [user, setUser] = useState<FirebaseUser | null>(null)
     const [loading, setLoading] = useState<boolean>(true)
     const [firebaseError, setFirebaseError] = useState<unknown | null>(null)

--- a/lib/types/auth.ts
+++ b/lib/types/auth.ts
@@ -5,8 +5,7 @@ export enum Role {
     USER = "USER",
 }
 
-export interface FirebaseAuthState {
-    user: FirebaseUser | null
+type FirebaseAuthStateBase = {
     role?: Role
     loading: boolean
     firebaseError: unknown
@@ -14,6 +13,11 @@ export interface FirebaseAuthState {
     signInWithGoogle: () => Promise<void>
 }
 
-export interface UserState {
+export type FirebaseAuthStateNullableUser = {
+    user: FirebaseUser | null
+} & FirebaseAuthStateBase
+
+export type FirebaseAuthState = {
     user: FirebaseUser
-}
+    email: string
+} & FirebaseAuthStateNullableUser

--- a/pages/_app.tsx
+++ b/pages/_app.tsx
@@ -1,7 +1,6 @@
 import type { AppProps } from "next/app"
 import React from "react"
 import { ChakraProvider } from "@chakra-ui/react"
-import { AuthProvider, UserProvider } from "@/lib/contexts/FirebaseAuthContext"
 import "styles/Calendar.css"
 import Layout from "@/components/common/Layout"
 import { MediaProvider } from "@/lib/contexts/MediaContext"
@@ -9,15 +8,11 @@ import { MediaProvider } from "@/lib/contexts/MediaContext"
 function MyApp({ Component, pageProps }: AppProps): JSX.Element {
     return (
         <MediaProvider>
-            <AuthProvider>
-                <ChakraProvider>
-                    <Layout>
-                        <UserProvider>
-                            <Component {...pageProps} />
-                        </UserProvider>
-                    </Layout>
-                </ChakraProvider>
-            </AuthProvider>
+            <ChakraProvider>
+                <Layout>
+                    <Component {...pageProps} />
+                </Layout>
+            </ChakraProvider>
         </MediaProvider>
     )
 }

--- a/pages/customer/[id]/edit.tsx
+++ b/pages/customer/[id]/edit.tsx
@@ -3,11 +3,11 @@ import type { NextPage } from "next"
 import ErrorAlert from "@/components/common/ErrorAlert"
 import Loading from "@/components/common/Loading"
 import { useRouter } from "next/dist/client/router"
-import { UserContext } from "@/lib/contexts/FirebaseAuthContext"
 import { EditCustomerForm } from "@/components/form/CustomerForm"
 import { useCustomerDetail } from "@/lib/hooks/useDetail"
 import FormPage from "@/components/common/FormPage"
 import { Box } from "@chakra-ui/react"
+import { AuthContext } from "@/lib/contexts/FirebaseAuthContext"
 
 type Props = {
     customerId: number
@@ -15,7 +15,7 @@ type Props = {
 
 function EditCustomerPage({ customerId }: Props): JSX.Element {
     const router = useRouter()
-    const { user } = useContext(UserContext)
+    const { user } = useContext(AuthContext)
 
     const customerDetailResponse = useCustomerDetail(customerId, user)
 

--- a/pages/customer/[id]/index.tsx
+++ b/pages/customer/[id]/index.tsx
@@ -5,20 +5,20 @@ import { useRouter } from "next/dist/client/router"
 import ErrorAlert from "@/components/common/ErrorAlert"
 import Loading from "@/components/common/Loading"
 import CustomerDetail from "@/components/detail/CustomerDetail"
-import { UserContext } from "@/lib/contexts/FirebaseAuthContext"
 import Link from "next/link"
 import { useCustomerDetail } from "@/lib/hooks/useDetail"
 import { StyledButton } from "@/components/common/Buttons"
 import StyledButtons from "@/components/common/StyledButtons"
 import FormPage from "@/components/common/FormPage"
 import FormSection from "@/components/common/FormSection"
+import { AuthContext } from "@/lib/contexts/FirebaseAuthContext"
 
 type Props = {
     customerId: number
 }
 
 function CustomerDetailPage({ customerId }: Props): JSX.Element {
-    const { user } = useContext(UserContext)
+    const { user } = useContext(AuthContext)
     const customerDetailResponse = useCustomerDetail(customerId, user)
 
     const getHeader = () =>

--- a/pages/customer/index.tsx
+++ b/pages/customer/index.tsx
@@ -3,12 +3,12 @@ import type { NextPage } from "next"
 import ErrorAlert from "@/components/common/ErrorAlert"
 import Loading from "@/components/common/Loading"
 import CustomerTable from "@/components/table/CustomerTable"
-import { UserContext } from "@/lib/contexts/FirebaseAuthContext"
 import { useCustomers } from "@/lib/hooks/useList"
 import FormPage from "@/components/common/FormPage"
+import { AuthContext } from "@/lib/contexts/FirebaseAuthContext"
 
 const Customers: NextPage = () => {
-    const { user } = useContext(UserContext)
+    const { user } = useContext(AuthContext)
     const customersResponse = useCustomers(user)
 
     return (

--- a/pages/employee/[id]/edit.tsx
+++ b/pages/employee/[id]/edit.tsx
@@ -3,11 +3,11 @@ import type { NextPage } from "next"
 import ErrorAlert from "@/components/common/ErrorAlert"
 import Loading from "@/components/common/Loading"
 import { useRouter } from "next/dist/client/router"
-import { UserContext } from "@/lib/contexts/FirebaseAuthContext"
 import { EditEmployeeForm } from "@/components/form/EmployeeForm"
 import { useEmployeeDetail } from "@/lib/hooks/useDetail"
 import FormPage from "@/components/common/FormPage"
 import { Box } from "@chakra-ui/react"
+import { AuthContext } from "@/lib/contexts/FirebaseAuthContext"
 
 type Props = {
     employeeId: number
@@ -15,7 +15,7 @@ type Props = {
 
 function EditEmployeePage({ employeeId }: Props): JSX.Element {
     const router = useRouter()
-    const { user } = useContext(UserContext)
+    const { user } = useContext(AuthContext)
 
     const employeeDetailResponse = useEmployeeDetail(employeeId, user)
 

--- a/pages/employee/[id]/index.tsx
+++ b/pages/employee/[id]/index.tsx
@@ -4,7 +4,6 @@ import { useRouter } from "next/dist/client/router"
 import ErrorAlert from "@/components/common/ErrorAlert"
 import Loading from "@/components/common/Loading"
 import EmployeeDetail from "@/components/detail/EmployeeDetail"
-import { UserContext } from "@/lib/contexts/FirebaseAuthContext"
 import { useEmployeeDetail } from "@/lib/hooks/useDetail"
 import {
     useTimesheets,
@@ -17,13 +16,14 @@ import { Box } from "@chakra-ui/react"
 import StyledButtons from "@/components/common/StyledButtons"
 import Link from "next/link"
 import { StyledButton } from "@/components/common/Buttons"
+import { AuthContext } from "@/lib/contexts/FirebaseAuthContext"
 
 type Props = {
     employeeId: number
 }
 
 function EmployeeDetailPage({ employeeId }: Props): JSX.Element {
-    const { user } = useContext(UserContext)
+    const { user } = useContext(AuthContext)
     const employeeDetailResponse = useEmployeeDetail(employeeId, user)
     const tasksResponse = useTasks(user)
     const timesheetsResponse = useTimesheets(

--- a/pages/employee/index.tsx
+++ b/pages/employee/index.tsx
@@ -3,7 +3,7 @@ import type { NextPage } from "next"
 import ErrorAlert from "@/components/common/ErrorAlert"
 import Loading from "@/components/common/Loading"
 import EmployeeTable from "@/components/table/EmployeeTable"
-import { AuthContext, UserContext } from "@/lib/contexts/FirebaseAuthContext"
+import { AuthContext } from "@/lib/contexts/FirebaseAuthContext"
 import { useEmployees } from "@/lib/hooks/useList"
 import { ApiGetResponse } from "@/lib/types/hooks"
 import { Employee } from "@/lib/types/apiTypes"
@@ -12,8 +12,7 @@ import AuthErrorAlert from "@/components/common/AuthErrorAlert"
 import FormPage from "@/components/common/FormPage"
 
 const Employees: NextPage = () => {
-    const { user } = useContext(UserContext)
-    const { role } = useContext(AuthContext)
+    const { user, role } = useContext(AuthContext)
     const initialEmployeeResponse = useEmployees(user)
 
     const [employeesResponse, setEmployeesResponse] = useState<

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -1,6 +1,5 @@
 import React, { useContext } from "react"
 import type { NextPage } from "next"
-import { UserContext } from "@/lib/contexts/FirebaseAuthContext"
 import ErrorAlert from "@/components/common/ErrorAlert"
 import Loading from "@/components/common/Loading"
 import {
@@ -11,13 +10,10 @@ import {
 import FormPage from "@/components/common/FormPage"
 import { Box } from "@chakra-ui/react"
 import TimesheetEntryEditor from "@/components/editor/TimesheetEntryEditor"
+import { AuthContext } from "@/lib/contexts/FirebaseAuthContext"
 
-interface IndexPageProps {
-    email: string
-}
-
-const IndexPage = ({ email }: IndexPageProps) => {
-    const { user } = useContext(UserContext)
+const Home: NextPage = () => {
+    const { user, email } = useContext(AuthContext)
     const timesheetsResponse = useTimesheets(user, undefined, email)
     const tasksResponse = useTasks(user)
 
@@ -70,11 +66,6 @@ const IndexPage = ({ email }: IndexPageProps) => {
             </Box>
         </FormPage>
     )
-}
-
-const Home: NextPage = () => {
-    const { user } = useContext(UserContext)
-    return user && user.email ? <IndexPage email={user.email} /> : null
 }
 
 export default Home

--- a/pages/project/[id]/edit.tsx
+++ b/pages/project/[id]/edit.tsx
@@ -4,11 +4,11 @@ import { EditProjectForm } from "@/components/form/ProjectForm"
 import ErrorAlert from "@/components/common/ErrorAlert"
 import Loading from "@/components/common/Loading"
 import { useRouter } from "next/dist/client/router"
-import { UserContext } from "@/lib/contexts/FirebaseAuthContext"
 import { useProjectDetail } from "@/lib/hooks/useDetail"
 import { useCustomers, useEmployees } from "@/lib/hooks/useList"
 import { Box } from "@chakra-ui/react"
 import FormPage from "@/components/common/FormPage"
+import { AuthContext } from "@/lib/contexts/FirebaseAuthContext"
 
 type Props = {
     projectId: number
@@ -16,7 +16,7 @@ type Props = {
 
 function EditProjectPage({ projectId }: Props): JSX.Element {
     const router = useRouter()
-    const { user } = useContext(UserContext)
+    const { user } = useContext(AuthContext)
 
     const customersResponse = useCustomers(user)
     const employeesResponse = useEmployees(user)

--- a/pages/project/[id]/index.tsx
+++ b/pages/project/[id]/index.tsx
@@ -16,7 +16,6 @@ import Link from "next/link"
 import TimesheetTable from "@/components/table/TimesheetTable"
 import TaskTable from "@/components/table/TaskTable"
 import ProjectDetail from "@/components/detail/ProjectDetail"
-import { UserContext } from "@/lib/contexts/FirebaseAuthContext"
 import { useProjectDetail } from "@/lib/hooks/useDetail"
 import { useTimesheets, useEmployees, useTasks } from "@/lib/hooks/useList"
 import { useUpdateProjects } from "@/lib/hooks/useUpdate"
@@ -28,6 +27,7 @@ import {
     StyledButton,
     RemoveIconButton,
 } from "@/components/common/Buttons"
+import { AuthContext } from "@/lib/contexts/FirebaseAuthContext"
 
 type Props = {
     projectId: number
@@ -36,7 +36,7 @@ type Props = {
 type ProjectStatus = "ACTIVE" | "ARCHIVED"
 
 function ProjectDetailPage({ projectId }: Props): JSX.Element {
-    const { user } = useContext(UserContext)
+    const { user } = useContext(AuthContext)
     const projectDetailResponse = useProjectDetail(projectId, user)
     const timesheetsResponse = useTimesheets(user, projectId)
     const employeesResponse = useEmployees(user)

--- a/pages/project/index.tsx
+++ b/pages/project/index.tsx
@@ -3,12 +3,12 @@ import type { NextPage } from "next"
 import ProjectTable from "@/components/table/ProjectTable"
 import ErrorAlert from "@/components/common/ErrorAlert"
 import Loading from "@/components/common/Loading"
-import { UserContext } from "@/lib/contexts/FirebaseAuthContext"
+import { AuthContext } from "@/lib/contexts/FirebaseAuthContext"
 import { useProjects } from "@/lib/hooks/useList"
 import FormPage from "@/components/common/FormPage"
 
 const Projects: NextPage = () => {
-    const { user } = useContext(UserContext)
+    const { user } = useContext(AuthContext)
     const projectsResponse = useProjects(user)
 
     return (

--- a/pages/project/new.tsx
+++ b/pages/project/new.tsx
@@ -6,14 +6,14 @@ import { CreateProjectForm } from "@/components/form/ProjectForm"
 import { useRouter } from "next/router"
 import { Project } from "@/lib/types/apiTypes"
 import { ApiUpdateResponse } from "@/lib/types/hooks"
-import { UserContext } from "@/lib/contexts/FirebaseAuthContext"
 import { useCustomers, useEmployees } from "@/lib/hooks/useList"
 import { Box } from "@chakra-ui/react"
 import FormPage from "@/components/common/FormPage"
+import { AuthContext } from "@/lib/contexts/FirebaseAuthContext"
 
 const New: NextPage = () => {
     const router = useRouter()
-    const { user } = useContext(UserContext)
+    const { user } = useContext(AuthContext)
     const customersResponse = useCustomers(user)
     const employeesResponse = useEmployees(user)
 

--- a/pages/report/index.tsx
+++ b/pages/report/index.tsx
@@ -1,6 +1,6 @@
 import React, { useContext } from "react"
 import type { NextPage } from "next"
-import { AuthContext, UserContext } from "@/lib/contexts/FirebaseAuthContext"
+import { AuthContext } from "@/lib/contexts/FirebaseAuthContext"
 import Loading from "@/components/common/Loading"
 import ErrorAlert from "@/components/common/ErrorAlert"
 import {
@@ -16,8 +16,7 @@ import FormPage from "@/components/common/FormPage"
 import ReportTable from "@/components/table/ReportTable"
 
 const Report: NextPage = () => {
-    const { user } = useContext(UserContext)
-    const { role } = useContext(AuthContext)
+    const { user, role } = useContext(AuthContext)
 
     const customersResponse = useCustomers(user)
     const projectsResponse = useProjects(user)

--- a/pages/timesheet/[id]/edit.tsx
+++ b/pages/timesheet/[id]/edit.tsx
@@ -5,9 +5,9 @@ import ErrorAlert from "@/components/common/ErrorAlert"
 import Loading from "@/components/common/Loading"
 import { useRouter } from "next/dist/client/router"
 import { EditTimesheetForm } from "@/components/form/TimesheetForm"
-import { UserContext } from "@/lib/contexts/FirebaseAuthContext"
 import { useTimesheetDetail } from "@/lib/hooks/useDetail"
 import { useEmployees } from "@/lib/hooks/useList"
+import { AuthContext } from "@/lib/contexts/FirebaseAuthContext"
 
 type Props = {
     timesheetId: number
@@ -15,7 +15,7 @@ type Props = {
 
 function EditTimesheetPage({ timesheetId }: Props): JSX.Element {
     const router = useRouter()
-    const { user } = useContext(UserContext)
+    const { user } = useContext(AuthContext)
 
     const timesheetDetailResponse = useTimesheetDetail(timesheetId, user)
     const employeesResponse = useEmployees(user)

--- a/pages/timesheet/[id]/index.tsx
+++ b/pages/timesheet/[id]/index.tsx
@@ -6,19 +6,19 @@ import ErrorAlert from "@/components/common/ErrorAlert"
 import Loading from "@/components/common/Loading"
 import TimesheetDetail from "@/components/detail/TimesheetDetail"
 import Link from "next/link"
-import { UserContext } from "@/lib/contexts/FirebaseAuthContext"
 import { useTimesheetDetail } from "@/lib/hooks/useDetail"
 import { StyledButton } from "@/components/common/Buttons"
 import StyledButtons from "@/components/common/StyledButtons"
 import FormSection from "@/components/common/FormSection"
 import FormPage from "@/components/common/FormPage"
+import { AuthContext } from "@/lib/contexts/FirebaseAuthContext"
 
 type Props = {
     timesheetId: number
 }
 
 function TimesheetDetailPage({ timesheetId }: Props): JSX.Element {
-    const { user } = useContext(UserContext)
+    const { user } = useContext(AuthContext)
     const timesheetDetailResponse = useTimesheetDetail(timesheetId, user)
 
     return (


### PR DESCRIPTION
There are two contexts `AuthContext` and `UserContext` which are basically the same. It makes no sense to have them separately.

I also made 'email' a required field in AuthContext. Makes it easier to use other hooks like the one in #330