### PR TITLE
Better REST hooks

### DIFF
--- a/__tests__/component/form/CreateCustomerForm.test.tsx
+++ b/__tests__/component/form/CreateCustomerForm.test.tsx
@@ -11,7 +11,6 @@ import {
     testCustomerRequiredFields,
 } from "../../fixtures"
 
-import { User } from "firebase/auth"
 import { customerFieldMetadata } from "@/lib/types/typeMetadata"
 import { checkTestRequestBodyRequiredFields } from "../../util"
 
@@ -22,7 +21,6 @@ const pathSpy = sinon.spy((path) => path)
 jest.mock("@/lib/utils/fetch", () => ({
     post: async (
         path: string,
-        _user: User,
         body: object
     ): Promise<ApiUpdateResponse<Customer>> =>
         (await pathSpy(path)) && bodySpy(body),

--- a/__tests__/component/form/CreateProjectForm.test.tsx
+++ b/__tests__/component/form/CreateProjectForm.test.tsx
@@ -15,7 +15,6 @@ import {
     testProjectRequiredFields,
 } from "../../fixtures"
 
-import { User } from "firebase/auth"
 import { projectFieldMetadata } from "@/lib/types/typeMetadata"
 import { checkTestRequestBodyRequiredFields } from "../../util"
 
@@ -26,7 +25,6 @@ const pathSpy = sinon.spy((path) => path)
 jest.mock("@/lib/utils/fetch", () => ({
     post: async (
         path: string,
-        _user: User,
         body: object
     ): Promise<ApiUpdateResponse<Project>> =>
         (await pathSpy(path)) && bodySpy(body),

--- a/__tests__/component/form/CreateTaskForm.test.tsx
+++ b/__tests__/component/form/CreateTaskForm.test.tsx
@@ -12,7 +12,6 @@ import {
     testTaskRequiredFields,
 } from "../../fixtures"
 
-import { User } from "firebase/auth"
 import { taskFieldMetadata } from "@/lib/types/typeMetadata"
 import { checkTestRequestBodyRequiredFields } from "../../util"
 
@@ -23,7 +22,6 @@ const pathSpy = sinon.spy((path) => path)
 jest.mock("@/lib/utils/fetch", () => ({
     post: async (
         path: string,
-        _user: User,
         body: object
     ): Promise<ApiUpdateResponse<Task>> =>
         (await pathSpy(path)) && bodySpy(body),

--- a/__tests__/component/form/CreateTimesheetEntryForm.test.tsx
+++ b/__tests__/component/form/CreateTimesheetEntryForm.test.tsx
@@ -13,7 +13,6 @@ import {
     testTimesheetEntryRequiredFields,
 } from "../../fixtures"
 
-import { User } from "firebase/auth"
 import { timesheetEntryFieldMetadata } from "@/lib/types/typeMetadata"
 import { checkTestRequestBodyRequiredFields } from "../../util"
 
@@ -24,7 +23,6 @@ const pathSpy = spy((path) => path)
 jest.mock("@/lib/utils/fetch", () => ({
     post: async (
         path: string,
-        _user: User,
         body: object
     ): Promise<ApiUpdateResponse<TimesheetEntry>> =>
         (await pathSpy(path)) && bodySpy(body),

--- a/__tests__/component/form/CreateTimesheetForm.test.tsx
+++ b/__tests__/component/form/CreateTimesheetForm.test.tsx
@@ -13,7 +13,6 @@ import {
     testTimesheetRequiredFields,
 } from "../../fixtures"
 
-import { User } from "firebase/auth"
 import { timesheetFieldMetadata } from "@/lib/types/typeMetadata"
 import { checkTestRequestBodyRequiredFields } from "../../util"
 
@@ -24,7 +23,6 @@ const pathSpy = sinon.spy((path) => path)
 jest.mock("@/lib/utils/fetch", () => ({
     post: async (
         path: string,
-        _user: User,
         body: object
     ): Promise<ApiUpdateResponse<Timesheet>> =>
         (await pathSpy(path)) && bodySpy(body),

--- a/__tests__/component/form/EditCustomerForm.test.tsx
+++ b/__tests__/component/form/EditCustomerForm.test.tsx
@@ -13,7 +13,6 @@ import {
     thirdTestCustomer,
 } from "../../fixtures"
 
-import { User } from "firebase/auth"
 import { customerFieldMetadata } from "@/lib/types/typeMetadata"
 import { checkTestRequestBodyRequiredFields } from "../../util"
 
@@ -24,7 +23,6 @@ const pathSpy = sinon.spy((path) => path)
 jest.mock("@/lib/utils/fetch", () => ({
     put: async (
         path: string,
-        _user: User,
         body: object
     ): Promise<ApiUpdateResponse<Customer>> =>
         (await pathSpy(path)) && bodySpy(body),

--- a/__tests__/component/form/EditEmployeeForm.test.tsx
+++ b/__tests__/component/form/EditEmployeeForm.test.tsx
@@ -13,7 +13,6 @@ import {
     thirdTestEmployee,
 } from "../../fixtures"
 
-import { User } from "firebase/auth"
 import { employeeFieldMetadata } from "@/lib/types/typeMetadata"
 import { checkTestRequestBodyRequiredFields } from "../../util"
 
@@ -24,7 +23,6 @@ const pathSpy = sinon.spy((path) => path)
 jest.mock("@/lib/utils/fetch", () => ({
     put: async (
         path: string,
-        _user: User,
         body: object
     ): Promise<ApiUpdateResponse<Employee>> =>
         (await pathSpy(path)) && bodySpy(body),

--- a/__tests__/component/form/EditProjectForm.test.tsx
+++ b/__tests__/component/form/EditProjectForm.test.tsx
@@ -16,7 +16,6 @@ import {
     testProjectRequiredFields,
 } from "../../fixtures"
 
-import { User } from "firebase/auth"
 import { projectFieldMetadata } from "@/lib/types/typeMetadata"
 import { checkTestRequestBodyRequiredFields } from "../../util"
 
@@ -27,7 +26,6 @@ const pathSpy = sinon.spy((path) => path)
 jest.mock("@/lib/utils/fetch", () => ({
     put: async (
         path: string,
-        _user: User,
         body: object
     ): Promise<ApiUpdateResponse<Project>> =>
         (await pathSpy(path)) && bodySpy(body),

--- a/__tests__/component/form/EditTaskForm.test.tsx
+++ b/__tests__/component/form/EditTaskForm.test.tsx
@@ -11,7 +11,6 @@ import {
     testTaskAllFields,
     testTaskRequiredFields,
 } from "../../fixtures"
-import { User } from "firebase/auth"
 import { EditTaskForm } from "@/components/form/TaskForm"
 
 import { taskFieldMetadata } from "@/lib/types/typeMetadata"
@@ -22,11 +21,7 @@ const bodySpy = sinon.spy((body) => body)
 const pathSpy = sinon.spy((path) => path)
 
 jest.mock("@/lib/utils/fetch", () => ({
-    put: async (
-        path: string,
-        _user: User,
-        body: object
-    ): Promise<ApiUpdateResponse<Task>> =>
+    put: async (path: string, body: object): Promise<ApiUpdateResponse<Task>> =>
         (await pathSpy(path)) && bodySpy(body),
 }))
 

--- a/__tests__/component/form/EditTimesheetEntryForm.test.tsx
+++ b/__tests__/component/form/EditTimesheetEntryForm.test.tsx
@@ -15,7 +15,6 @@ import {
     testTimesheetEntryRequiredFields,
 } from "../../fixtures"
 
-import { User } from "firebase/auth"
 import { timesheetEntryFieldMetadata } from "@/lib/types/typeMetadata"
 import { checkTestRequestBodyRequiredFields } from "../../util"
 
@@ -26,7 +25,6 @@ const pathSpy = spy((path) => path)
 jest.mock("@/lib/utils/fetch", () => ({
     put: async (
         path: string,
-        _user: User,
         body: object
     ): Promise<ApiUpdateResponse<TimesheetEntry>> =>
         (await pathSpy(path)) && bodySpy(body),

--- a/__tests__/component/form/EditTimesheetForm.test.tsx
+++ b/__tests__/component/form/EditTimesheetForm.test.tsx
@@ -14,7 +14,6 @@ import {
     testTimesheetRequiredFields,
 } from "../../fixtures"
 
-import { User } from "firebase/auth"
 import { timesheetFieldMetadata } from "@/lib/types/typeMetadata"
 import { checkTestRequestBodyRequiredFields } from "../../util"
 
@@ -25,7 +24,6 @@ const pathSpy = sinon.spy((path) => path)
 jest.mock("@/lib/utils/fetch", () => ({
     put: async (
         path: string,
-        _user: User,
         body: object
     ): Promise<ApiUpdateResponse<Timesheet>> =>
         (await pathSpy(path)) && bodySpy(body),

--- a/components/editor/TimesheetEntryEditor/DayEditor.tsx
+++ b/components/editor/TimesheetEntryEditor/DayEditor.tsx
@@ -2,7 +2,6 @@ import { SortingOrderIconButton } from "@/components/common/Buttons"
 import Header from "@/components/common/Header"
 import { CreateTimesheetEntryForm } from "@/components/form/TimesheetEntryForm"
 import ImportFromCSVModal from "@/components/modal/ImportFromCSVModal"
-import { AuthContext } from "@/lib/contexts/FirebaseAuthContext"
 import { MediaContext } from "@/lib/contexts/MediaContext"
 import { useUpdateTimesheetEntries } from "@/lib/hooks/useUpdate"
 import { Task, Timesheet, TimesheetEntry } from "@/lib/types/apiTypes"
@@ -56,9 +55,7 @@ const DayEditor = ({
     setTimesheetEntries,
 }: IDayEditor): JSX.Element => {
     const { isLarge } = useContext(MediaContext)
-
-    const { user } = useContext(AuthContext)
-    const { delete: del } = useUpdateTimesheetEntries(user)
+    const { delete: del } = useUpdateTimesheetEntries()
 
     const [timesheet, setTimesheet] = useState<Timesheet | undefined>(undefined)
 

--- a/components/form/CustomerForm.tsx
+++ b/components/form/CustomerForm.tsx
@@ -1,5 +1,5 @@
 import { FormControl, FormLabel, Input, Box } from "@chakra-ui/react"
-import React, { Dispatch, SetStateAction, useContext, useState } from "react"
+import React, { Dispatch, SetStateAction, useState } from "react"
 import { Customer } from "@/lib/types/apiTypes"
 import { useUpdateCustomers } from "@/lib/hooks/useUpdate"
 import { FormBase } from "@/lib/types/forms"
@@ -8,7 +8,6 @@ import { customerFieldMetadata } from "@/lib/types/typeMetadata"
 import FormSection from "../common/FormSection"
 import StyledButtons from "../common/StyledButtons"
 import { StyledButton } from "../common/Buttons"
-import { AuthContext } from "@/lib/contexts/FirebaseAuthContext"
 
 type CustomerFormPropsBase = FormBase<Customer>
 type CustomerFields = Partial<Customer>
@@ -110,15 +109,11 @@ function CustomerForm({
 export const CreateCustomerForm = (
     props: CreateCustomerFormProps
 ): JSX.Element => {
-    const { user } = useContext(AuthContext)
-    const { post } = useUpdateCustomers(user)
-
+    const { post } = useUpdateCustomers()
     const { customer } = props
-
     const [customerFields, setCustomerFields] = useState<CustomerFields>(
         customer || {}
     )
-
     const [errorMessage, setErrorMessage] = useState<string>("")
     const errorHandler = (error: Error) => setErrorMessage(`${error}`)
 
@@ -152,15 +147,11 @@ export const CreateCustomerForm = (
 }
 
 export const EditCustomerForm = (props: EditCustomerFormProps): JSX.Element => {
-    const { user } = useContext(AuthContext)
-    const { put } = useUpdateCustomers(user)
-
+    const { put } = useUpdateCustomers()
     const { customer } = props
-
     const [customerFields, setCustomerFields] = useState<CustomerFields>(
         customer || {}
     )
-
     const [errorMessage, setErrorMessage] = useState<string>("")
     const errorHandler = (error: Error) => setErrorMessage(`${error}`)
 
@@ -190,15 +181,11 @@ export const EditCustomerForm = (props: EditCustomerFormProps): JSX.Element => {
 export const AddCustomerForm = (
     props: CreateCustomerFormProps
 ): JSX.Element => {
-    const { user } = useContext(AuthContext)
-    const { post } = useUpdateCustomers(user)
-
+    const { post } = useUpdateCustomers()
     const { customer } = props
-
     const [customerFields, setCustomerFields] = useState<CustomerFields>(
         customer || {}
     )
-
     const [errorMessage, setErrorMessage] = useState<string>("")
     const errorHandler = (error: Error) => setErrorMessage(`${error}`)
 

--- a/components/form/EmployeeForm.tsx
+++ b/components/form/EmployeeForm.tsx
@@ -1,5 +1,5 @@
 import { FormControl, FormLabel, Input, Box, Select } from "@chakra-ui/react"
-import React, { useContext, useEffect, useState } from "react"
+import React, { useEffect, useState } from "react"
 import { Employee } from "@/lib/types/apiTypes"
 import { useUpdateEmployees } from "@/lib/hooks/useUpdate"
 import { FormBase } from "@/lib/types/forms"
@@ -10,7 +10,6 @@ import StyledButtons from "../common/StyledButtons"
 import { StyledButton } from "../common/Buttons"
 import { isError } from "lodash"
 import FormSection from "../common/FormSection"
-import { AuthContext } from "@/lib/contexts/FirebaseAuthContext"
 
 type CreateEmployeeFormProps = FormBase<Employee>
 
@@ -243,11 +242,8 @@ const EmployeeForm = ({ onSubmit, onCancel, employee }: EmployeeFormProps) => {
 }
 
 export const EditEmployeeForm = (props: EditEmployeeFormProps): JSX.Element => {
-    const { user } = useContext(AuthContext)
-    const { put } = useUpdateEmployees(user)
-
+    const { put } = useUpdateEmployees()
     const { employee } = props
-
     const [errorMessage, setErrorMessage] = useState<string>("")
     const errorHandler = (error: Error) => setErrorMessage(`${error}`)
 

--- a/components/form/ProjectForm.tsx
+++ b/components/form/ProjectForm.tsx
@@ -11,13 +11,12 @@ import {
     Select,
     Box,
 } from "@chakra-ui/react"
-import React, { useContext, useState } from "react"
+import React, { useState } from "react"
 import ErrorAlert from "../common/ErrorAlert"
 import FormSection from "../common/FormSection"
 import { NewCustomerModal } from "../common/FormFields"
 import StyledButtons from "../common/StyledButtons"
 import { StyledButton } from "../common/Buttons"
-import { AuthContext } from "@/lib/contexts/FirebaseAuthContext"
 
 type CreateProjectFormProps = FormBase<Project> & {
     employees: Employee[]
@@ -279,9 +278,7 @@ function ProjectForm({
 export const CreateProjectForm = (
     props: CreateProjectFormProps
 ): JSX.Element => {
-    const { user } = useContext(AuthContext)
-    const { post } = useUpdateProjects(user)
-
+    const { post } = useUpdateProjects()
     const [errorMessage, setErrorMessage] = useState<string>("")
     const errorHandler = (error: Error) => setErrorMessage(`${error}`)
 
@@ -304,8 +301,7 @@ export const CreateProjectForm = (
 }
 
 export const EditProjectForm = (props: EditProjectFormProps): JSX.Element => {
-    const { user } = useContext(AuthContext)
-    const { put } = useUpdateProjects(user)
+    const { put } = useUpdateProjects()
 
     const [errorMessage, setErrorMessage] = useState<string>("")
     const errorHandler = (error: Error) => setErrorMessage(`${error}`)

--- a/components/form/TaskForm.tsx
+++ b/components/form/TaskForm.tsx
@@ -2,13 +2,12 @@ import { useUpdateTasks } from "@/lib/hooks/useUpdate"
 import { Project, Task } from "@/lib/types/apiTypes"
 import { FormBase } from "@/lib/types/forms"
 import { Box, Flex, FormControl, FormLabel, Input } from "@chakra-ui/react"
-import React, { useContext, useState } from "react"
+import React, { useState } from "react"
 import ErrorAlert from "../common/ErrorAlert"
 import { CheckBoxField, FormContainer } from "../common/FormFields"
 import { taskFieldMetadata } from "@/lib/types/typeMetadata"
 import StyledButtons from "../common/StyledButtons"
 import { StyledButton } from "../common/Buttons"
-import { AuthContext } from "@/lib/contexts/FirebaseAuthContext"
 
 type CreateTaskFormProps = FormBase<Task> & {
     project: Project
@@ -137,8 +136,7 @@ function TaskForm({
 }
 
 export const CreateTaskForm = (props: CreateTaskFormProps): JSX.Element => {
-    const { user } = useContext(AuthContext)
-    const { post } = useUpdateTasks(user)
+    const { post } = useUpdateTasks()
 
     const [errorMessage, setErrorMessage] = useState<string>("")
     const errorHandler = (error: Error) => setErrorMessage(`${error}`)
@@ -162,9 +160,7 @@ export const CreateTaskForm = (props: CreateTaskFormProps): JSX.Element => {
 }
 
 export const EditTaskForm = (props: EditTaskFormProps): JSX.Element => {
-    const { user } = useContext(AuthContext)
-    const { put } = useUpdateTasks(user)
-
+    const { put } = useUpdateTasks()
     const [errorMessage, setErrorMessage] = useState<string>("")
     const errorHandler = (error: Error) => setErrorMessage(`${error}`)
 

--- a/components/form/TimesheetEntryForm.tsx
+++ b/components/form/TimesheetEntryForm.tsx
@@ -8,13 +8,7 @@ import {
     Input,
     Select,
 } from "@chakra-ui/react"
-import React, {
-    Dispatch,
-    SetStateAction,
-    useContext,
-    useRef,
-    useState,
-} from "react"
+import React, { Dispatch, SetStateAction, useRef, useState } from "react"
 import ErrorAlert from "../common/ErrorAlert"
 import { FormButtons } from "../common/FormFields"
 import { timesheetEntryFieldMetadata } from "@/lib/types/typeMetadata"
@@ -24,7 +18,6 @@ import {
     useUpdateTimesheetEntry,
 } from "@/lib/hooks/useUpdate"
 import { isError } from "lodash"
-import { AuthContext } from "@/lib/contexts/FirebaseAuthContext"
 
 type TSetState<T> = Dispatch<SetStateAction<T>>
 type TimesheetEntryFields = Partial<TimesheetEntry>
@@ -232,13 +225,10 @@ export const EditTimesheetEntryForm = ({
     afterSubmit,
     ...props
 }: EditTimesheetEntryFormProps): JSX.Element => {
-    const { user } = useContext(AuthContext)
-    const { put } = useUpdateTimesheetEntry(user)
-
+    const { put } = useUpdateTimesheetEntry()
     const [errorMessage, setErrorMessage] = useState<string>("")
     const [timesheetEntryFields, setTimesheetEntryFields] =
         useState<TimesheetEntryFields>(timesheetEntry)
-
     const errorHandler = (error: Error) => setErrorMessage(error.toString())
 
     const handlePut = async () => {
@@ -293,9 +283,7 @@ export const CreateTimesheetEntryForm = ({
     afterSubmit,
     ...props
 }: CreateTimesheetEntryFormProps): JSX.Element => {
-    const { user } = useContext(AuthContext)
-    const { post } = useUpdateTimesheetEntries(user)
-
+    const { post } = useUpdateTimesheetEntries()
     const [errorMessage, setErrorMessage] = useState<string>("")
     const [timesheetEntryFields, setTimesheetEntryFields] =
         useState<TimesheetEntryFields>({

--- a/components/form/TimesheetForm.tsx
+++ b/components/form/TimesheetForm.tsx
@@ -269,9 +269,7 @@ function TimesheetForm({
 export const CreateTimesheetForm = (
     props: CreateTimesheetFormProps
 ): JSX.Element => {
-    const { user } = useContext(AuthContext)
-    const { post } = useUpdateTimesheets(user)
-
+    const { post } = useUpdateTimesheets()
     const [errorMessage, setErrorMessage] = useState<string>("")
     const errorHandler = (error: Error) => setErrorMessage(`${error}`)
 
@@ -296,9 +294,7 @@ export const CreateTimesheetForm = (
 export const EditTimesheetForm = (
     props: EditTimesheetFormProps
 ): JSX.Element => {
-    const { user } = useContext(AuthContext)
-    const { put } = useUpdateTimesheets(user)
-
+    const { put } = useUpdateTimesheets()
     const [errorMessage, setErrorMessage] = useState<string>("")
     const errorHandler = (error: Error) => setErrorMessage(`${error}`)
 

--- a/components/modal/ImportFromCSVModal.tsx
+++ b/components/modal/ImportFromCSVModal.tsx
@@ -52,10 +52,10 @@ const ImportFromCSVModal = ({
     setTimesheetEntries,
 }: IImportCsvDialog): JSX.Element => {
     const { user } = useContext(AuthContext)
-    const { post } = useUpdateTimesheetEntries(user)
+    const { post } = useUpdateTimesheetEntries()
 
-    const timesheets = useTimesheets(user)
-    const tasks = useTasks(user)
+    const timesheets = useTimesheets()
+    const tasks = useTasks()
 
     const { isOpen, onOpen, onClose } = useDisclosure()
 

--- a/components/table/EmployeeTable.tsx
+++ b/components/table/EmployeeTable.tsx
@@ -10,13 +10,12 @@ import React, {
     useState,
 } from "react"
 import Link from "next/link"
-import { User } from "firebase/auth"
 import { ApiGetResponse } from "@/lib/types/hooks"
-import { firebaseSyncEndpoint, useGet } from "@/lib/hooks/swrInterface"
 import FormSection from "../common/FormSection"
 import StyledButtons from "../common/StyledButtons"
 import { CustomButton } from "../common/Buttons"
 import { MediaContext } from "@/lib/contexts/MediaContext"
+import { useEmployeeSync } from "@/lib/hooks/misc"
 
 interface EmployeeRowProps {
     employee: Employee
@@ -40,20 +39,15 @@ const EmployeeRow = ({ employee, isLarge }: EmployeeRowProps): JSX.Element => (
 )
 
 interface ISyncEmployeesButton {
-    user: User
     setEmployeesResponse: Dispatch<SetStateAction<ApiGetResponse<Employee[]>>>
 }
 
 export const SyncEmployeesButton = ({
-    user,
     setEmployeesResponse,
 }: ISyncEmployeesButton): JSX.Element => {
     const [shouldSync, setShouldSync] = useState<boolean>(false)
 
-    const employeeSyncResponse = useGet<Employee[]>(
-        user,
-        shouldSync ? firebaseSyncEndpoint("employee-sync") : null
-    )
+    const employeeSyncResponse = useEmployeeSync(shouldSync)
 
     useEffect(() => {
         if (shouldSync && employeeSyncResponse?.isSuccess) {
@@ -84,13 +78,11 @@ export const SyncEmployeesButton = ({
 }
 
 interface EmployeeTableProps {
-    user: User
     employeesResponse?: ApiGetResponse<Employee[]>
     setEmployeesResponse: Dispatch<SetStateAction<ApiGetResponse<Employee[]>>>
 }
 
 const EmployeeTable = ({
-    user,
     employeesResponse,
     setEmployeesResponse,
 }: EmployeeTableProps): JSX.Element => {
@@ -134,7 +126,6 @@ const EmployeeTable = ({
             )}
             <StyledButtons>
                 <SyncEmployeesButton
-                    user={user}
                     setEmployeesResponse={setEmployeesResponse}
                 />
             </StyledButtons>

--- a/components/table/ReportTable/TableButtons.tsx
+++ b/components/table/ReportTable/TableButtons.tsx
@@ -48,12 +48,7 @@ const TableButtons = ({
 }: ITableButtons): JSX.Element => {
     const timesheetsEntries: TTEResponse | TUnsuccess =
         startDate && endDate
-            ? useTimesheetEntries(
-                  user,
-                  startDate,
-                  endDate,
-                  selectedEmployee?.email
-              )
+            ? useTimesheetEntries(startDate, endDate, selectedEmployee?.email)
             : unSuccess
 
     const filteredEntries = timesheetsEntries.isSuccess

--- a/components/table/ReportTable/index.tsx
+++ b/components/table/ReportTable/index.tsx
@@ -64,7 +64,7 @@ const ReportTable = ({
 
     const reportsResponse =
         role === Role.ADMIN && startDate && endDate
-            ? useTimesheetEntries(user, startDate, endDate)
+            ? useTimesheetEntries(startDate, endDate)
             : undefined
     const allEntries = reportsResponse?.isSuccess ? reportsResponse.data : []
 

--- a/components/table/TaskTable.tsx
+++ b/components/table/TaskTable.tsx
@@ -10,13 +10,12 @@ import {
     Tbody,
 } from "@chakra-ui/react"
 import { Table, Td, Th, Thead, Tr } from "@chakra-ui/table"
-import React, { useContext, useState } from "react"
+import React, { useState } from "react"
 import { StyledButton, RemoveIconButton } from "../common/Buttons"
 import ErrorAlert from "../common/ErrorAlert"
 import StyledButtons from "../common/StyledButtons"
 import FormSection from "../common/FormSection"
 import { CreateTaskForm, EditTaskForm } from "../form/TaskForm"
-import { AuthContext } from "@/lib/contexts/FirebaseAuthContext"
 
 interface TaskRowProps {
     task: Task
@@ -24,8 +23,7 @@ interface TaskRowProps {
 }
 
 function TaskRow({ task, onClick }: TaskRowProps): JSX.Element {
-    const { user } = useContext(AuthContext)
-    const { put } = useUpdateTasks(user)
+    const { put } = useUpdateTasks()
 
     const [errorMessage, setErrorMessage] = useState<string>()
     const errorHandler = (error: Error) => setErrorMessage(`${error}`)

--- a/components/table/TimesheetTable.tsx
+++ b/components/table/TimesheetTable.tsx
@@ -7,7 +7,7 @@ import {
     ModalOverlay,
 } from "@chakra-ui/react"
 import { Table, Tbody, Td, Th, Thead, Tr } from "@chakra-ui/table"
-import React, { useContext, useState } from "react"
+import React, { useState } from "react"
 import ErrorAlert from "../common/ErrorAlert"
 import { Employee, Project, Timesheet } from "@/lib/types/apiTypes"
 import { CreateTimesheetForm } from "../form/TimesheetForm"
@@ -16,15 +16,13 @@ import { useUpdateTimesheets } from "@/lib/hooks/useUpdate"
 import FormSection from "../common/FormSection"
 import StyledButtons from "../common/StyledButtons"
 import { RemoveIconButton, StyledButton } from "../common/Buttons"
-import { AuthContext } from "@/lib/contexts/FirebaseAuthContext"
 
 interface TimesheetRowProps {
     timesheet: Timesheet
 }
 function TimesheetRow({ timesheet }: TimesheetRowProps): JSX.Element {
     const router = useRouter()
-    const { user } = useContext(AuthContext)
-    const { put } = useUpdateTimesheets(user)
+    const { put } = useUpdateTimesheets()
 
     const [errorMessage, setErrorMessage] = useState<string>()
     const errorHandler = (error: Error) => setErrorMessage(`${error}`)

--- a/lib/hooks/misc.ts
+++ b/lib/hooks/misc.ts
@@ -1,0 +1,28 @@
+import { useContext } from "react"
+import { AuthContext } from "../contexts/FirebaseAuthContext"
+import { Employee } from "../types/apiTypes"
+import {
+    Endpoint,
+    firebaseSyncEndpoint,
+    listEndpoint,
+    useGet,
+} from "./swrInterface"
+
+export const useEmployeeSync = (shouldSync: boolean) => {
+    const { user } = useContext(AuthContext)
+    return useGet<Employee[]>(
+        shouldSync ? firebaseSyncEndpoint("employee-sync") : null,
+        [],
+        user
+    )
+}
+
+export const useFlex = () => {
+    const { user, email } = useContext(AuthContext)
+    return useGet<Employee[]>(
+        listEndpoint("timesheet-entry/flex" as Endpoint),
+        [],
+        user,
+        { email }
+    )
+}

--- a/lib/hooks/useDetail.ts
+++ b/lib/hooks/useDetail.ts
@@ -1,24 +1,25 @@
-import { User } from "firebase/auth"
+import { useContext } from "react"
+import { AuthContext } from "../contexts/FirebaseAuthContext"
 import { Customer, Project, Timesheet, Employee } from "../types/apiTypes"
 import { ApiGetResponse } from "../types/hooks"
-import { useGet, detailEndpoint } from "./swrInterface"
+import { detailEndpoint, useGet } from "./swrInterface"
 
-export const useCustomerDetail = (
-    id: number,
-    user: User
-): ApiGetResponse<Customer> => useGet(user, detailEndpoint("customer", id))
+export const useCustomerDetail = (id: number): ApiGetResponse<Customer> => {
+    const { user } = useContext(AuthContext)
+    return useGet(detailEndpoint("customer", id), ["customer"], user)
+}
 
-export const useProjectDetail = (
-    id: number,
-    user: User
-): ApiGetResponse<Project> => useGet(user, detailEndpoint("project", id))
+export const useProjectDetail = (id: number): ApiGetResponse<Project> => {
+    const { user } = useContext(AuthContext)
+    return useGet(detailEndpoint("project", id), ["project"], user)
+}
 
-export const useTimesheetDetail = (
-    id: number,
-    user: User
-): ApiGetResponse<Timesheet> => useGet(user, detailEndpoint("timesheet", id))
+export const useTimesheetDetail = (id: number): ApiGetResponse<Timesheet> => {
+    const { user } = useContext(AuthContext)
+    return useGet(detailEndpoint("timesheet", id), ["timesheet"], user)
+}
 
-export const useEmployeeDetail = (
-    id: number,
-    user: User
-): ApiGetResponse<Employee> => useGet(user, detailEndpoint("employee", id))
+export const useEmployeeDetail = (id: number): ApiGetResponse<Employee> => {
+    const { user } = useContext(AuthContext)
+    return useGet(detailEndpoint("employee", id), ["employee"], user)
+}

--- a/lib/hooks/useHoliday.ts
+++ b/lib/hooks/useHoliday.ts
@@ -1,6 +1,6 @@
-import { useEffect, useState } from "react"
 import { ApiGetResponse } from "../types/hooks"
 import { NEXT_PUBLIC_GOOGLE_APIKEY } from "../conf"
+import { useGet } from "./swrInterface"
 
 type Holiday = {
     date: string
@@ -8,60 +8,33 @@ type Holiday = {
     summary: string
 }
 
-interface IData extends Holiday {
+type IData = {
     start: {
         date: string
     }
-}
+} & Holiday
 
-function parseEvents(data: { items: IData[] }): Holiday[] {
-    const { items } = data
-    const holidays = []
-    for (const item of items) {
-        const { date } = item.start
-        const { description } = item
-        const { summary } = item
-        holidays.push({ date, description, summary })
-    }
-    return holidays
-}
+const parseEvents = (items: IData[]): Holiday[] =>
+    items.map(({ start, description, summary }) => ({
+        date: start.date,
+        description,
+        summary,
+    }))
 
 export const useHoliday = (): ApiGetResponse<Holiday[]> => {
     const GOOGLE_API_URL =
         "www.googleapis.com/calendar/v3/calendars/fi.finnish%23holiday%40group.v.calendar.google.com"
-    const [response, setResponse] = useState<ApiGetResponse<Holiday[]>>({
-        isSuccess: false,
-        isLoading: true,
-        isError: false,
+    const url = `https://${GOOGLE_API_URL}/events`
+    const response = useGet<{ items: IData[] }>(url, [], undefined, {
+        key: NEXT_PUBLIC_GOOGLE_APIKEY || "",
     })
 
-    useEffect(() => {
-        const fetchData = async () => {
-            try {
-                const apiResponse = await fetch(
-                    `https://${GOOGLE_API_URL}/events?key=${NEXT_PUBLIC_GOOGLE_APIKEY}`
-                )
-                const data = await apiResponse.json()
-                const parsedData = parseEvents(data)
-                setResponse({
-                    isSuccess: true,
-                    isLoading: false,
-                    isError: false,
-                    data: parsedData,
-                })
-            } catch (error) {
-                setResponse({
-                    isSuccess: false,
-                    isLoading: false,
-                    isError: true,
-                    errorMessage: "Error",
-                })
-            }
-        }
-
-        fetchData()
-    }, [])
-
+    if (response.isSuccess) {
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        const { items } = response.data
+        const holidays = parseEvents(items)
+        return { ...response, data: holidays }
+    }
     return response
 }
 

--- a/lib/hooks/useList.ts
+++ b/lib/hooks/useList.ts
@@ -1,4 +1,6 @@
 import { User } from "firebase/auth"
+import { useContext } from "react"
+import { AuthContext } from "../contexts/FirebaseAuthContext"
 import {
     Customer,
     Employee,
@@ -24,42 +26,55 @@ const pushOptionalFields = (
     return record
 }
 
-export const useCustomers = (user: User): ApiGetResponse<Customer[]> =>
-    useGet(user, listEndpoint("customer"))
+export const useCustomers = (): ApiGetResponse<Customer[]> => {
+    const { user } = useContext(AuthContext)
+    return useGet(listEndpoint("customer"), ["customer"], user)
+}
 
-export const useProjects = (user: User): ApiGetResponse<Project[]> =>
-    useGet(user, listEndpoint("project"))
+export const useProjects = (): ApiGetResponse<Project[]> => {
+    const { user } = useContext(AuthContext)
+    return useGet(listEndpoint("project"), ["project"], user)
+}
 
-export const useEmployees = (user: User): ApiGetResponse<Employee[]> =>
-    useGet(user, listEndpoint("employee"))
+export const useEmployees = (): ApiGetResponse<Employee[]> => {
+    const { user } = useContext(AuthContext)
+    return useGet(listEndpoint("employee"), ["employee"], user)
+}
 
-export const useTasks = (
-    user: User,
-    projectId?: number
-): ApiGetResponse<Task[]> =>
-    useGet(user, listEndpoint("task"), pushOptionalFields({}, { projectId }))
+export const useTasks = (projectId?: number): ApiGetResponse<Task[]> => {
+    const { user } = useContext(AuthContext)
+    return useGet(
+        listEndpoint("task"),
+        ["task"],
+        user,
+        pushOptionalFields({}, { projectId })
+    )
+}
 
 export const useTimesheets = (
-    user: User,
     projectId?: number,
     email?: string
-): ApiGetResponse<Timesheet[]> =>
-    useGet(
-        user,
+): ApiGetResponse<Timesheet[]> => {
+    const { user } = useContext(AuthContext)
+    return useGet(
         listEndpoint("timesheet"),
+        ["timesheet"],
+        user,
         pushOptionalFields({}, { projectId, email })
     )
+}
 
 export const useTimesheetEntries = (
-    user: User,
     startDate: string,
     endDate: string,
     email?: string,
     timesheetId?: number
-): ApiGetResponse<TimesheetEntry[]> =>
-    useGet(
-        user,
+): ApiGetResponse<TimesheetEntry[]> => {
+    const { user } = useContext(AuthContext)
+    return useGet(
         listEndpoint("timesheet-entry"),
+        ["timesheet-entry"],
+        user,
         pushOptionalFields(
             {
                 startDate,
@@ -68,3 +83,4 @@ export const useTimesheetEntries = (
             { email, timesheetId }
         )
     )
+}

--- a/lib/hooks/useUpdate.ts
+++ b/lib/hooks/useUpdate.ts
@@ -7,28 +7,41 @@ import {
     TimesheetEntry,
 } from "../types/apiTypes"
 import { UpdateHook } from "../types/hooks"
-import { User } from "firebase/auth"
 import { useUpdate } from "./swrInterface"
+import { useContext } from "react"
+import { AuthContext } from "../contexts/FirebaseAuthContext"
 
-export const useUpdateCustomers = (user: User): UpdateHook<Customer> =>
-    useUpdate("customer", user)
+export const useUpdateCustomers = (): UpdateHook<Customer> => {
+    const { user } = useContext(AuthContext)
+    return useUpdate("customer", user)
+}
 
-export const useUpdateProjects = (user: User): UpdateHook<Project> =>
-    useUpdate("project", user)
+export const useUpdateProjects = (): UpdateHook<Project> => {
+    const { user } = useContext(AuthContext)
+    return useUpdate("project", user)
+}
 
-export const useUpdateTasks = (user: User): UpdateHook<Task> =>
-    useUpdate("task", user)
+export const useUpdateTasks = (): UpdateHook<Task> => {
+    const { user } = useContext(AuthContext)
+    return useUpdate("task", user)
+}
 
-export const useUpdateTimesheets = (user: User): UpdateHook<Timesheet> =>
-    useUpdate("timesheet", user)
+export const useUpdateTimesheets = (): UpdateHook<Timesheet> => {
+    const { user } = useContext(AuthContext)
+    return useUpdate("timesheet", user)
+}
 
-export const useUpdateTimesheetEntry = (
-    user: User
-): UpdateHook<TimesheetEntry> => useUpdate("timesheet-entry", user)
+export const useUpdateTimesheetEntry = (): UpdateHook<TimesheetEntry> => {
+    const { user } = useContext(AuthContext)
+    return useUpdate("timesheet-entry", user)
+}
 
-export const useUpdateTimesheetEntries = (
-    user: User
-): UpdateHook<TimesheetEntry[]> => useUpdate("timesheet-entry", user)
+export const useUpdateTimesheetEntries = (): UpdateHook<TimesheetEntry[]> => {
+    const { user } = useContext(AuthContext)
+    return useUpdate("timesheet-entry", user)
+}
 
-export const useUpdateEmployees = (user: User): UpdateHook<Employee> =>
-    useUpdate("employee", user)
+export const useUpdateEmployees = (): UpdateHook<Employee> => {
+    const { user } = useContext(AuthContext)
+    return useUpdate("employee", user)
+}

--- a/lib/utils/fetch.ts
+++ b/lib/utils/fetch.ts
@@ -1,11 +1,16 @@
 import { User } from "firebase/auth"
 
-async function httpText(path: string, user: User): Promise<string> {
-    const jwt = await user.getIdToken()
+async function httpText(path: string, user?: User): Promise<string> {
+    const jwt = user && (await user.getIdToken())
+    const auth = jwt
+        ? {
+              Authorization: `Bearer ${jwt}`,
+          }
+        : undefined
     const request = new Request(path, {
         headers: {
+            ...auth,
             "Content-Type": "text/plain",
-            Authorization: `Bearer ${jwt}`,
         },
     })
     const response = await fetch(request)
@@ -14,14 +19,19 @@ async function httpText(path: string, user: User): Promise<string> {
 
 async function httpJSON<T>(
     path: string,
-    user: User,
+    user?: User,
     config?: RequestInit
 ): Promise<T> {
-    const jwt = await user.getIdToken()
+    const jwt = user && (await user.getIdToken())
+    const auth = jwt
+        ? {
+              Authorization: `Bearer ${jwt}`,
+          }
+        : undefined
     const request = new Request(path, {
         headers: {
+            ...auth,
             "Content-Type": "application/json",
-            Authorization: `Bearer ${jwt}`,
         },
         ...config,
     })
@@ -48,7 +58,7 @@ export const pathToUrl = (
 
 export function getText(
     path: string,
-    user: User,
+    user?: User,
     params?: Record<string, string | number>
 ) {
     const url = pathToUrl(path, params)
@@ -57,7 +67,7 @@ export function getText(
 
 export function getJSON<T>(
     path: string,
-    user: User,
+    user?: User,
     params?: Record<string, string | number>,
     config?: RequestInit
 ): Promise<T> {
@@ -68,8 +78,8 @@ export function getJSON<T>(
 
 export function post<T, U>(
     path: string,
-    user: User,
     body: T,
+    user?: User,
     params?: Record<string, string | number>,
     config?: RequestInit
 ): Promise<U> {
@@ -84,8 +94,8 @@ export function post<T, U>(
 
 export function put<T, U>(
     path: string,
-    user: User,
     body: T,
+    user?: User,
     config?: RequestInit
 ): Promise<U> {
     const init = {
@@ -100,7 +110,7 @@ export function put<T, U>(
 // delete is a reserved keyword
 export function del<T>(
     path: string,
-    user: User,
+    user?: User,
     config?: RequestInit
 ): Promise<T> {
     const init = {

--- a/lib/utils/matchMutate.ts
+++ b/lib/utils/matchMutate.ts
@@ -2,7 +2,7 @@ import { useSWRConfig } from "swr"
 
 export const useMatchMutate = () => {
     const { cache, mutate } = useSWRConfig()
-    return (matcher: RegExp, ...args: unknown[]) => {
+    return (fun: (key: string) => boolean, ...args: unknown[]) => {
         if (!(cache instanceof Map)) {
             throw new Error(
                 "matchMutate requires the cache provider to be a Map instance"
@@ -12,7 +12,7 @@ export const useMatchMutate = () => {
         const keys: string[] = []
 
         Array.from(cache.keys()).forEach((element: string) => {
-            if (matcher.test(element)) {
+            if (fun(element)) {
                 keys.push(element)
             }
         })

--- a/pages/customer/[id]/edit.tsx
+++ b/pages/customer/[id]/edit.tsx
@@ -1,4 +1,4 @@
-import React, { useContext } from "react"
+import React from "react"
 import type { NextPage } from "next"
 import ErrorAlert from "@/components/common/ErrorAlert"
 import Loading from "@/components/common/Loading"
@@ -7,7 +7,6 @@ import { EditCustomerForm } from "@/components/form/CustomerForm"
 import { useCustomerDetail } from "@/lib/hooks/useDetail"
 import FormPage from "@/components/common/FormPage"
 import { Box } from "@chakra-ui/react"
-import { AuthContext } from "@/lib/contexts/FirebaseAuthContext"
 
 type Props = {
     customerId: number
@@ -15,9 +14,8 @@ type Props = {
 
 function EditCustomerPage({ customerId }: Props): JSX.Element {
     const router = useRouter()
-    const { user } = useContext(AuthContext)
 
-    const customerDetailResponse = useCustomerDetail(customerId, user)
+    const customerDetailResponse = useCustomerDetail(customerId)
 
     const errorMessage =
         (customerDetailResponse.isError &&

--- a/pages/customer/[id]/index.tsx
+++ b/pages/customer/[id]/index.tsx
@@ -1,4 +1,4 @@
-import React, { useContext } from "react"
+import React from "react"
 import { Box } from "@chakra-ui/layout"
 import type { NextPage } from "next"
 import { useRouter } from "next/dist/client/router"
@@ -11,15 +11,13 @@ import { StyledButton } from "@/components/common/Buttons"
 import StyledButtons from "@/components/common/StyledButtons"
 import FormPage from "@/components/common/FormPage"
 import FormSection from "@/components/common/FormSection"
-import { AuthContext } from "@/lib/contexts/FirebaseAuthContext"
 
 type Props = {
     customerId: number
 }
 
 function CustomerDetailPage({ customerId }: Props): JSX.Element {
-    const { user } = useContext(AuthContext)
-    const customerDetailResponse = useCustomerDetail(customerId, user)
+    const customerDetailResponse = useCustomerDetail(customerId)
 
     const getHeader = () =>
         customerDetailResponse.isSuccess

--- a/pages/customer/index.tsx
+++ b/pages/customer/index.tsx
@@ -1,15 +1,13 @@
-import React, { useContext } from "react"
+import React from "react"
 import type { NextPage } from "next"
 import ErrorAlert from "@/components/common/ErrorAlert"
 import Loading from "@/components/common/Loading"
 import CustomerTable from "@/components/table/CustomerTable"
 import { useCustomers } from "@/lib/hooks/useList"
 import FormPage from "@/components/common/FormPage"
-import { AuthContext } from "@/lib/contexts/FirebaseAuthContext"
 
 const Customers: NextPage = () => {
-    const { user } = useContext(AuthContext)
-    const customersResponse = useCustomers(user)
+    const customersResponse = useCustomers()
 
     return (
         <FormPage header="Customers">

--- a/pages/employee/[id]/edit.tsx
+++ b/pages/employee/[id]/edit.tsx
@@ -1,4 +1,4 @@
-import React, { useContext } from "react"
+import React from "react"
 import type { NextPage } from "next"
 import ErrorAlert from "@/components/common/ErrorAlert"
 import Loading from "@/components/common/Loading"
@@ -7,7 +7,6 @@ import { EditEmployeeForm } from "@/components/form/EmployeeForm"
 import { useEmployeeDetail } from "@/lib/hooks/useDetail"
 import FormPage from "@/components/common/FormPage"
 import { Box } from "@chakra-ui/react"
-import { AuthContext } from "@/lib/contexts/FirebaseAuthContext"
 
 type Props = {
     employeeId: number
@@ -15,9 +14,8 @@ type Props = {
 
 function EditEmployeePage({ employeeId }: Props): JSX.Element {
     const router = useRouter()
-    const { user } = useContext(AuthContext)
 
-    const employeeDetailResponse = useEmployeeDetail(employeeId, user)
+    const employeeDetailResponse = useEmployeeDetail(employeeId)
 
     const errorMessage =
         (employeeDetailResponse.isError &&

--- a/pages/employee/[id]/index.tsx
+++ b/pages/employee/[id]/index.tsx
@@ -1,4 +1,4 @@
-import React, { useContext } from "react"
+import React from "react"
 import type { NextPage } from "next"
 import { useRouter } from "next/dist/client/router"
 import ErrorAlert from "@/components/common/ErrorAlert"
@@ -16,18 +16,15 @@ import { Box } from "@chakra-ui/react"
 import StyledButtons from "@/components/common/StyledButtons"
 import Link from "next/link"
 import { StyledButton } from "@/components/common/Buttons"
-import { AuthContext } from "@/lib/contexts/FirebaseAuthContext"
 
 type Props = {
     employeeId: number
 }
 
 function EmployeeDetailPage({ employeeId }: Props): JSX.Element {
-    const { user } = useContext(AuthContext)
-    const employeeDetailResponse = useEmployeeDetail(employeeId, user)
-    const tasksResponse = useTasks(user)
+    const employeeDetailResponse = useEmployeeDetail(employeeId)
+    const tasksResponse = useTasks()
     const timesheetsResponse = useTimesheets(
-        user,
         undefined,
         employeeDetailResponse.isSuccess
             ? employeeDetailResponse.data.email
@@ -38,7 +35,6 @@ function EmployeeDetailPage({ employeeId }: Props): JSX.Element {
     const endDate = "9999-01-01"
 
     const timesheetEntriesResponse = useTimesheetEntries(
-        user,
         startDate,
         endDate,
         employeeDetailResponse.isSuccess

--- a/pages/employee/index.tsx
+++ b/pages/employee/index.tsx
@@ -12,8 +12,8 @@ import AuthErrorAlert from "@/components/common/AuthErrorAlert"
 import FormPage from "@/components/common/FormPage"
 
 const Employees: NextPage = () => {
-    const { user, role } = useContext(AuthContext)
-    const initialEmployeeResponse = useEmployees(user)
+    const { role } = useContext(AuthContext)
+    const initialEmployeeResponse = useEmployees()
 
     const [employeesResponse, setEmployeesResponse] = useState<
         ApiGetResponse<Employee[]>
@@ -45,7 +45,6 @@ const Employees: NextPage = () => {
             )}
             {employeesResponse?.isSuccess && (
                 <EmployeeTable
-                    user={user}
                     employeesResponse={employeesResponse}
                     setEmployeesResponse={setEmployeesResponse}
                 />

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -13,15 +13,14 @@ import TimesheetEntryEditor from "@/components/editor/TimesheetEntryEditor"
 import { AuthContext } from "@/lib/contexts/FirebaseAuthContext"
 
 const Home: NextPage = () => {
-    const { user, email } = useContext(AuthContext)
-    const timesheetsResponse = useTimesheets(user, undefined, email)
-    const tasksResponse = useTasks(user)
+    const { email } = useContext(AuthContext)
+    const timesheetsResponse = useTimesheets(undefined, email)
+    const tasksResponse = useTasks()
 
     const startDate = "0000-01-01"
     const endDate = "9999-01-01"
 
     const timesheetEntriesResponse = useTimesheetEntries(
-        user,
         startDate,
         endDate,
         email

--- a/pages/project/[id]/edit.tsx
+++ b/pages/project/[id]/edit.tsx
@@ -1,4 +1,4 @@
-import React, { useContext } from "react"
+import React from "react"
 import type { NextPage } from "next"
 import { EditProjectForm } from "@/components/form/ProjectForm"
 import ErrorAlert from "@/components/common/ErrorAlert"
@@ -8,7 +8,6 @@ import { useProjectDetail } from "@/lib/hooks/useDetail"
 import { useCustomers, useEmployees } from "@/lib/hooks/useList"
 import { Box } from "@chakra-ui/react"
 import FormPage from "@/components/common/FormPage"
-import { AuthContext } from "@/lib/contexts/FirebaseAuthContext"
 
 type Props = {
     projectId: number
@@ -16,11 +15,10 @@ type Props = {
 
 function EditProjectPage({ projectId }: Props): JSX.Element {
     const router = useRouter()
-    const { user } = useContext(AuthContext)
 
-    const customersResponse = useCustomers(user)
-    const employeesResponse = useEmployees(user)
-    const projectDetailResponse = useProjectDetail(projectId, user)
+    const customersResponse = useCustomers()
+    const employeesResponse = useEmployees()
+    const projectDetailResponse = useProjectDetail(projectId)
 
     const errorMessage =
         (customersResponse.isError && customersResponse.errorMessage) ||

--- a/pages/project/[id]/index.tsx
+++ b/pages/project/[id]/index.tsx
@@ -1,4 +1,4 @@
-import React, { useContext, useState } from "react"
+import React, { useState } from "react"
 import { Box } from "@chakra-ui/layout"
 import type { NextPage } from "next"
 import { useRouter } from "next/dist/client/router"
@@ -27,7 +27,6 @@ import {
     StyledButton,
     RemoveIconButton,
 } from "@/components/common/Buttons"
-import { AuthContext } from "@/lib/contexts/FirebaseAuthContext"
 
 type Props = {
     projectId: number
@@ -36,13 +35,12 @@ type Props = {
 type ProjectStatus = "ACTIVE" | "ARCHIVED"
 
 function ProjectDetailPage({ projectId }: Props): JSX.Element {
-    const { user } = useContext(AuthContext)
-    const projectDetailResponse = useProjectDetail(projectId, user)
-    const timesheetsResponse = useTimesheets(user, projectId)
-    const employeesResponse = useEmployees(user)
-    const tasksResponse = useTasks(user, projectId)
+    const projectDetailResponse = useProjectDetail(projectId)
+    const timesheetsResponse = useTimesheets(projectId)
+    const employeesResponse = useEmployees()
+    const tasksResponse = useTasks()
 
-    const { put } = useUpdateProjects(user)
+    const { put } = useUpdateProjects()
 
     const [displayArchivedModal, setDisplayArchivedModal] = useState(false)
     const [errorMessage, setErrorMessage] = useState<string>("")

--- a/pages/project/index.tsx
+++ b/pages/project/index.tsx
@@ -1,15 +1,13 @@
-import React, { useContext } from "react"
+import React from "react"
 import type { NextPage } from "next"
 import ProjectTable from "@/components/table/ProjectTable"
 import ErrorAlert from "@/components/common/ErrorAlert"
 import Loading from "@/components/common/Loading"
-import { AuthContext } from "@/lib/contexts/FirebaseAuthContext"
 import { useProjects } from "@/lib/hooks/useList"
 import FormPage from "@/components/common/FormPage"
 
 const Projects: NextPage = () => {
-    const { user } = useContext(AuthContext)
-    const projectsResponse = useProjects(user)
+    const projectsResponse = useProjects()
 
     return (
         <FormPage header="Projects">

--- a/pages/project/new.tsx
+++ b/pages/project/new.tsx
@@ -1,4 +1,4 @@
-import React, { useContext } from "react"
+import React from "react"
 import type { NextPage } from "next"
 import ErrorAlert from "@/components/common/ErrorAlert"
 import Loading from "@/components/common/Loading"
@@ -9,13 +9,11 @@ import { ApiUpdateResponse } from "@/lib/types/hooks"
 import { useCustomers, useEmployees } from "@/lib/hooks/useList"
 import { Box } from "@chakra-ui/react"
 import FormPage from "@/components/common/FormPage"
-import { AuthContext } from "@/lib/contexts/FirebaseAuthContext"
 
 const New: NextPage = () => {
     const router = useRouter()
-    const { user } = useContext(AuthContext)
-    const customersResponse = useCustomers(user)
-    const employeesResponse = useEmployees(user)
+    const customersResponse = useCustomers()
+    const employeesResponse = useEmployees()
 
     const errorMessage =
         (customersResponse.isError && customersResponse.errorMessage) ||

--- a/pages/report/index.tsx
+++ b/pages/report/index.tsx
@@ -18,11 +18,11 @@ import ReportTable from "@/components/table/ReportTable"
 const Report: NextPage = () => {
     const { user, role } = useContext(AuthContext)
 
-    const customersResponse = useCustomers(user)
-    const projectsResponse = useProjects(user)
-    const employeeResponse = useEmployees(user)
-    const timesheetsResponse = useTimesheets(user)
-    const tasksResponse = useTasks(user)
+    const customersResponse = useCustomers()
+    const projectsResponse = useProjects()
+    const employeeResponse = useEmployees()
+    const timesheetsResponse = useTimesheets()
+    const tasksResponse = useTasks()
 
     const isLoading =
         customersResponse.isLoading ||

--- a/pages/timesheet/[id]/edit.tsx
+++ b/pages/timesheet/[id]/edit.tsx
@@ -1,4 +1,4 @@
-import React, { useContext } from "react"
+import React from "react"
 import type { NextPage } from "next"
 import { Heading } from "@chakra-ui/layout"
 import ErrorAlert from "@/components/common/ErrorAlert"
@@ -7,7 +7,6 @@ import { useRouter } from "next/dist/client/router"
 import { EditTimesheetForm } from "@/components/form/TimesheetForm"
 import { useTimesheetDetail } from "@/lib/hooks/useDetail"
 import { useEmployees } from "@/lib/hooks/useList"
-import { AuthContext } from "@/lib/contexts/FirebaseAuthContext"
 
 type Props = {
     timesheetId: number
@@ -15,10 +14,8 @@ type Props = {
 
 function EditTimesheetPage({ timesheetId }: Props): JSX.Element {
     const router = useRouter()
-    const { user } = useContext(AuthContext)
-
-    const timesheetDetailResponse = useTimesheetDetail(timesheetId, user)
-    const employeesResponse = useEmployees(user)
+    const timesheetDetailResponse = useTimesheetDetail(timesheetId)
+    const employeesResponse = useEmployees()
 
     const errorMessage =
         (timesheetDetailResponse.isError &&

--- a/pages/timesheet/[id]/index.tsx
+++ b/pages/timesheet/[id]/index.tsx
@@ -1,4 +1,4 @@
-import React, { useContext } from "react"
+import React from "react"
 import { Box } from "@chakra-ui/layout"
 import type { NextPage } from "next"
 import { useRouter } from "next/dist/client/router"
@@ -11,15 +11,13 @@ import { StyledButton } from "@/components/common/Buttons"
 import StyledButtons from "@/components/common/StyledButtons"
 import FormSection from "@/components/common/FormSection"
 import FormPage from "@/components/common/FormPage"
-import { AuthContext } from "@/lib/contexts/FirebaseAuthContext"
 
 type Props = {
     timesheetId: number
 }
 
 function TimesheetDetailPage({ timesheetId }: Props): JSX.Element {
-    const { user } = useContext(AuthContext)
-    const timesheetDetailResponse = useTimesheetDetail(timesheetId, user)
+    const timesheetDetailResponse = useTimesheetDetail(timesheetId)
 
     return (
         <FormPage header="moi">


### PR DESCRIPTION
Proposed update: In the future, the syntax for creating an AJAX hook that is compatible with the existing codebase would be simply:
```typescript
    useGet<Example>(
        "http://example.com",
        []
    )
```
This would return an `ApiGetRequest<Example>` that knows how to handle the different states of the HTTP request in the component.

Introducing dependencies, i.e. telling the frontend to refresh the fetched data when some other data is posted would simply be i.e.
```typescript
    useGet<Example>(
        "http://example.com",
        ["employee"]
    )
```
A hook defined this way would know to refresh itself whenever an `Employee` update is posted or putte'd. This is achieved by using JSON values as cache keys within SWR. Telling swr to update certain record is then a matter of [a simple one liner](https://github.com/three-consulting/epoc-frontend/pull/332/files#diff-90a5a44810a52267ace6948883c4ac5526ec21b1779dd86121f709cd2701e478R85).

PS: Also defined an `useFlex` hook for @venlavanhalathree [here](https://github.com/three-consulting/epoc-frontend/pull/332/files#diff-203a0d499665c3026c16380e8d604ba8fdc835ce43de90bf13a17143d036e0d7R17-R23) and improved the hook api throughout the app by removing extra `user` args according to a suggestion by @LeadingMoominExpert 
