### PR TITLE
don't render main when login is pending

### DIFF
--- a/components/common/Main.tsx
+++ b/components/common/Main.tsx
@@ -21,9 +21,11 @@ const PleaseLogInPage = ({ isLarge }: { isLarge: boolean }) => (
 
 const Main = ({ children }: MainProps): JSX.Element => {
     const auth = useFirebaseAuth()
-    const { user } = auth
+    const { user, loading } = auth
     const { isLarge } = useContext(MediaContext)
-    return (
+    return loading ? (
+        <></>
+    ) : (
         <Flex
             flexDirection="row"
             alignContent="center"

--- a/lib/hooks/useFirebaseAuth.ts
+++ b/lib/hooks/useFirebaseAuth.ts
@@ -27,6 +27,7 @@ export default function useFirebaseAuth(): FirebaseAuthStateNullableUser {
     const signOutAndClear = async () => {
         await signOut(auth)
         clear()
+        setLoading(false)
     }
 
     const signInWithGoogle = async () => {


### PR DESCRIPTION
As per `main` the app doesn't properly handle a pending login: When the user has clicked `log in` they still see `log in` for a while on the screen. It would probably be better to just render nothing while that request is pending.